### PR TITLE
Implement a pyinstaller spec for generating a Windows pySHACL exe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,7 +361,6 @@ deb_dist/
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
-*.spec
 
 # Installer logs
 pip-log.txt

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -5,3 +5,7 @@
 
 **Nicholas Car**
 * a few small admin bits and pieces
+
+**Jonathan Yu**
+* pyinstaller spec for compiling pySHACL cli as a Windows binary
+

--- a/README.md
+++ b/README.md
@@ -93,6 +93,29 @@ optional arguments:
                         Send output to a file (defaults to stdout).
 ```
 
+## Windows CLI
+
+[Pyinstaller](https://www.pyinstaller.org/) can be 
+[used](https://pyinstaller.readthedocs.io/en/stable/usage.html) to create an 
+executable for Windows that has the same characteristics as the Linux/Mac 
+CLI program. 
+The necessary ``.spec`` file is already included in ``pyshacl/pyshacl-cli.spec``.
+The ``pyshacl-cli.spec`` PyInstaller spec file creates a ``.exe`` for the 
+pySHACL Command Line utility. See above for the pySHACL command line util usage instructions.
+
+See [the PyInstaller installation guide](https://pyinstaller.readthedocs.io/en/stable/installation.html#installing-in-windows) for info on how to install PyInstaller for Windows.
+
+Once you have pyinstaller, use pyinstaller to generate the ``pyshacl.exe`` CLI file like so:
+```
+    $ cd src/pyshacl
+    $ pyinstaller pyshacl-cli.spec
+```
+This will output ``pyshacl.exe`` in the ``dist`` directory in ``src/pyshacl``.
+
+You can now run the pySHACL Command Line utility via ``pyshacl.exe``. 
+See above for the pySHACL command line util usage instructions.
+
+
 ## Python Module Use
 For basic use of this module, you can just call the `validate` function of the `pyshacl` module like this:
 

--- a/pyshacl/pyshacl-cli.spec
+++ b/pyshacl/pyshacl-cli.spec
@@ -1,0 +1,53 @@
+# -*- mode: python ; coding: utf-8 -*-
+## run `pyinstaller pyshacl-cli.spec` to create `dist/pyshacl.exe` dist
+## note it requires pywin32
+
+block_cipher = None
+
+a = Analysis(
+            ['cli.py'],
+            pathex=['.'],
+            binaries=[
+                ('shacl-shacl.pickle','.')
+            ],
+            datas=[
+            ],
+            hiddenimports=[
+                'rdflib.plugins',
+                'rdflib',
+                'urllib3',
+                'rdflib_jsonld',
+                'win32com.gen_py',
+                'pkg_resources.py2_warn'
+            ],
+            hookspath=[],
+            runtime_hooks=[],
+            excludes=[],
+            win_no_prefer_redirects=False,
+            win_private_assemblies=False,
+            cipher=block_cipher,
+            noarchive=False
+)
+
+pyz = PYZ(
+            a.pure,
+            a.zipped_data,
+            cipher=block_cipher
+)
+
+exe = EXE(
+            pyz,
+            a.scripts,
+            a.binaries,
+            a.zipfiles,
+            a.datas,
+            [],
+            name='pyshacl',
+            debug=False,
+            bootloader_ignore_signals=False,
+            strip=False,
+            upx=True,
+            upx_exclude=[],
+            runtime_tmpdir=None,
+            console=True
+)

--- a/pyshacl/validate.py
+++ b/pyshacl/validate.py
@@ -199,8 +199,14 @@ def meta_validate(shacl_graph, inference='rdfs', **kwargs):
     if shacl_shacl_graph is None:
         from os import path
         import pickle
-        here_dir = path.dirname(__file__)
-        pickle_file = path.join(here_dir, "shacl-shacl.pickle")
+        import sys
+        if getattr( sys, 'frozen', False ) :
+                # runs in a pyinstaller bundle
+                here_dir = sys._MEIPASS
+                pickle_file = path.join(here_dir, "shacl-shacl.pickle")                            
+        else :
+                here_dir = path.dirname(__file__)
+                pickle_file = path.join(here_dir, "shacl-shacl.pickle")            
         with open(pickle_file, 'rb') as shacl_pickle:
             u = pickle.Unpickler(shacl_pickle, fix_imports=False)
             shacl_shacl_store = u.load()


### PR DESCRIPTION
Implements a pathway to create a pySHACL CLI .exe for Windows using pyinstaller.

Simply adds a pyinstaller spec to generate the exe. The output `pyshacl.exe` has been tested with the `pyshacl.exe` works with `test/resource/cmdline_tests/`.

Output exe attached below as a zip. 

[pyshacl.zip](https://github.com/RDFLib/pySHACL/files/4222889/pyshacl.zip)
