### PR TITLE
Catch error due to seek on closed jsonld file

### DIFF
--- a/pyshacl/rdfutil/load.py
+++ b/pyshacl/rdfutil/load.py
@@ -305,6 +305,8 @@ def load_from_source(
                 source.seek(0)
             except (AttributeError, UnsupportedOperation):
                 pass
+            except ValueError:
+                pass
         source_is_graph = True
     elif source_is_graph and (g != source):
         # clone source into g

--- a/test/resources/cmdline_tests/d1.jsonld
+++ b/test/resources/cmdline_tests/d1.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "ex": "http://example.com/ex#",
+    "exOnt": "http://example.com/exOnt#",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#"
+  },
+  "@graph": [
+    {
+      "@id": "ex:Pet1",
+      "@type": "exOnt:Lizard",
+      "exOnt:nLegs": 4,
+      "rdf:label": "Sebastian"
+    },
+    {
+      "@id": "ex:Human1",
+      "@type": "exOnt:Human",
+      "exOnt:hasPet": {
+        "@id": "ex:Pet1"
+      },
+      "exOnt:nLegs": 2,
+      "rdf:label": "Amy"
+    }
+  ]
+}

--- a/test/test_cmdline.py
+++ b/test/test_cmdline.py
@@ -149,6 +149,45 @@ def test_cmdline_web():
     assert res.returncode == 0
     return True
 
+
+def test_cmdline_jsonld():
+    if not hasattr(subprocess, 'run'):
+        print("Subprocess.run() not available, skip this test")
+        assert True
+        return
+    if platform.system() == "Windows":
+        print("Commandline tests cannot run on Windows.")
+        assert True
+        return True
+    if os.environ.get("PYBUILD_NAME", None) is not None:
+        print("We don't have access to scripts dir during pybuild process.")
+        assert True
+        return True
+    DEB_BUILD_ARCH = os.environ.get('DEB_BUILD_ARCH', None)
+    DEB_HOST_ARCH = os.environ.get('DEB_HOST_ARCH', None)
+    if DEB_BUILD_ARCH is not None or DEB_HOST_ARCH is not None:
+        print("Cannot run web requests in debhelper tests.")
+        assert True
+        return True
+    graph_file = path.join(cmdline_files_dir, 'd1.jsonld')
+    shacl_file = "https://raw.githubusercontent.com/RDFLib/pySHACL/master/test/resources/cmdline_tests/s1.ttl"
+    ont_file = "https://raw.githubusercontent.com/RDFLib/pySHACL/master/test/resources/cmdline_tests/o1.ttl"
+    cmd = pyshacl_command
+    args = [
+        graph_file,
+        '-df', 'json-ld',
+        '-s', shacl_file,
+        '-i', 'rdfs',
+        '-e', ont_file
+    ]
+    res = subprocess.run(cmd+args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    print("result = {}".format(res.returncode))
+    print(res.stdout.decode('utf-8'))
+    print(res.stderr.decode('utf-8'))
+    assert res.returncode == 0
+    return True
+
+
 if __name__ == "__main__":
     test_cmdline()
     test_cmdline_fail()


### PR DESCRIPTION
This PR Closes #62 where @ashleysommer identified that pyshacl tries to `seek(0)` on a file already closed by the `rdflib-jsonld` package.

## What this changes

- [X] Adds a jsonld serialization of a test dataset
- [X] Adds a test for the command line call raising the issue
- [X] Catches the ValueError that is raised and just passes it