### PR TITLE
Add the ability for SHACL rules to operate iteratively.

### DIFF
--- a/pyshacl/cli.py
+++ b/pyshacl/cli.py
@@ -135,6 +135,7 @@ parser.add_argument(
 )
 # parser.add_argument('-h', '--help', action="help", help='Show this help text.')
 
+
 def main():
     basename = os.path.basename(sys.argv[0])
     if basename == "__main__.py":

--- a/pyshacl/cli.py
+++ b/pyshacl/cli.py
@@ -76,6 +76,13 @@ parser.add_argument(
     default=False,
     help='Enable features from the SHACL-JS Specification.',
 )
+parser.add_argument(
+    '--iterate-rules',
+    dest='iterate_rules',
+    action='store_true',
+    default=False,
+    help="Run Shape's SHACL Rules iteratively until the data_graph reaches a steady state.",
+)
 parser.add_argument('--abort', dest='abort', action='store_true', default=False, help='Abort on first error.')
 parser.add_argument(
     '-d', '--debug', dest='debug', action='store_true', default=False, help='Output additional runtime messages.'
@@ -128,7 +135,6 @@ parser.add_argument(
 )
 # parser.add_argument('-h', '--help', action="help", help='Show this help text.')
 
-
 def main():
     basename = os.path.basename(sys.argv[0])
     if basename == "__main__.py":
@@ -151,6 +157,11 @@ def main():
         validator_kwargs['advanced'] = True
     if args.js:
         validator_kwargs['js'] = True
+    if args.iterate_rules:
+        if not args.advanced:
+            sys.stderr.write("Iterate-Rules option only works when you enable Advanced Mode.\n")
+        else:
+            validator_kwargs['iterate_rules'] = True
     if args.abort:
         validator_kwargs['abort_on_error'] = True
     if args.shacl_file_format:

--- a/pyshacl/extras/js/rules.py
+++ b/pyshacl/extras/js/rules.py
@@ -3,12 +3,14 @@
 import typing
 
 from pyshacl.consts import SH
+from pyshacl.errors import ReportableRuntimeError
 from pyshacl.rules.shacl_rule import SHACLRule
 
 from .js_executable import JSExecutable
 
 
 if typing.TYPE_CHECKING:
+    from pyshacl.pytypes import GraphLike
     from pyshacl.shape import Shape
     from pyshacl.shapes_graph import ShapesGraph
 
@@ -18,26 +20,45 @@ SH_JSRule = SH.term('JSRule')
 class JSRule(SHACLRule):
     __slots__ = ('js_exe',)
 
-    def __init__(self, shape: 'Shape', rule_node):
-        super(JSRule, self).__init__(shape, rule_node)
+    def __init__(self, shape: 'Shape', rule_node, **kwargs):
+        super(JSRule, self).__init__(shape, rule_node, **kwargs)
         shapes_graph = shape.sg  # type: ShapesGraph
         self.js_exe = JSExecutable(shapes_graph, rule_node)
 
-    def apply(self, data_graph):
+    def apply(self, data_graph: 'GraphLike') -> int:
         focus_nodes = self.shape.focus_nodes(data_graph)  # uses target nodes to find focus nodes
-        applicable_nodes = self.filter_conditions(focus_nodes, data_graph)
-        sets_to_add = []
-        for a in applicable_nodes:
-            args_map = {"this": a}
-            results = self.js_exe.execute(data_graph, args_map, mode="construct")
-            triples = results['_result']
-            if triples is not None and isinstance(triples, (list, tuple)):
-                set_to_add = set()
-                for t in triples:
-                    s, p, o = t[:3]
-                    set_to_add.add((s, p, o))
-                sets_to_add.append(set_to_add)
-        for s in sets_to_add:
-            for t in s:
-                data_graph.add(t)
-        return
+        all_added = 0
+        iterate_limit = 100
+        while True:
+            if iterate_limit < 1:
+                raise ReportableRuntimeError("Local rule iteration exceeded iteration limit of 100.")
+            iterate_limit -= 1
+            added = 0
+            applicable_nodes = self.filter_conditions(focus_nodes, data_graph)
+            sets_to_add = []
+            for a in applicable_nodes:
+                args_map = {"this": a}
+                results = self.js_exe.execute(data_graph, args_map, mode="construct")
+                triples = results['_result']
+                this_added = False
+                if triples is not None and isinstance(triples, (list, tuple)):
+                    set_to_add = set()
+                    for t in triples:
+                        s, p, o = tr = t[:3]
+                        if tr not in data_graph:
+                            this_added = True
+                            set_to_add.add(tr)
+                    sets_to_add.append(set_to_add)
+                if this_added:
+                    added += 1
+            if added > 0:
+                all_added += added
+                for s in sets_to_add:
+                    for t in s:
+                        data_graph.add(t)
+                if self.iterate:
+                    continue  # Jump up to iterate
+                else:
+                    break  # Don't iterate
+            break
+        return all_added

--- a/pyshacl/extras/js/rules.py
+++ b/pyshacl/extras/js/rules.py
@@ -45,9 +45,9 @@ class JSRule(SHACLRule):
                     set_to_add = set()
                     for t in triples:
                         s, p, o = tr = t[:3]
-                        if tr not in data_graph:
+                        if not this_added and tr not in data_graph:
                             this_added = True
-                            set_to_add.add(tr)
+                        set_to_add.add(tr)
                     sets_to_add.append(set_to_add)
                 if this_added:
                     added += 1

--- a/pyshacl/rules/shacl_rule.py
+++ b/pyshacl/rules/shacl_rule.py
@@ -25,9 +25,9 @@ class SHACLRuleCondition(object):
 
 
 class SHACLRule(object):
-    __slots__ = ("shape", "node", "_deactivated")
+    __slots__ = ("shape", "node", "iterate", "_deactivated")
 
-    def __init__(self, shape, rule_node):
+    def __init__(self, shape, rule_node, iterate=False):
         """
 
         :param shape:
@@ -38,6 +38,8 @@ class SHACLRule(object):
         super(SHACLRule, self).__init__()
         self.shape = shape
         self.node = rule_node
+        self.iterate = False
+
         deactivated_nodes = list(self.shape.sg.objects(self.node, SH_deactivated))
         self._deactivated = len(deactivated_nodes) > 0 and bool(deactivated_nodes[0])
 

--- a/pyshacl/rules/sparql/__init__.py
+++ b/pyshacl/rules/sparql/__init__.py
@@ -74,7 +74,7 @@ class SPARQLRule(SHACLRule):
                         raise ReportableRuntimeError("Query executed by a SHACL SPARQLRule must be CONSTRUCT query.")
                     this_added = False
                     for i in results.graph:
-                        if i not in data_graph:
+                        if not this_added and i not in data_graph:
                             this_added = True
                             # We only need to know at least one triple was added, then break!
                             break

--- a/pyshacl/rules/sparql/__init__.py
+++ b/pyshacl/rules/sparql/__init__.py
@@ -15,6 +15,7 @@ from ..shacl_rule import SHACLRule
 
 
 if TYPE_CHECKING:
+    from pyshacl.pytypes import GraphLike
     from pyshacl.shape import Shape
 
 XSD_string = XSD.term('string')
@@ -23,7 +24,7 @@ XSD_string = XSD.term('string')
 class SPARQLRule(SHACLRule):
     __slots__ = ("_constructs", "_qh")
 
-    def __init__(self, shape: 'Shape', rule_node: 'rdflib.term.Identifier'):
+    def __init__(self, shape: 'Shape', rule_node: 'rdflib.term.Identifier', **kwargs):
         """
 
         :param shape:
@@ -31,7 +32,7 @@ class SPARQLRule(SHACLRule):
         :param rule_node:
         :type rule_node: rdflib.term.Identifier
         """
-        super(SPARQLRule, self).__init__(shape, rule_node)
+        super(SPARQLRule, self).__init__(shape, rule_node, **kwargs)
         construct_nodes = set(self.shape.sg.objects(self.node, SH_construct))
         if len(construct_nodes) < 1:
             raise RuleLoadError("No sh:construct on SPARQLRule", "https://www.w3.org/TR/shacl-af/#SPARQLRule")
@@ -49,21 +50,44 @@ class SPARQLRule(SHACLRule):
         query_helper.collect_prefixes()
         self._qh = query_helper
 
-    def apply(self, data_graph):
+    def apply(self, data_graph: 'GraphLike') -> int:
         focus_nodes = self.shape.focus_nodes(data_graph)  # uses target nodes to find focus nodes
-        applicable_nodes = self.filter_conditions(focus_nodes, data_graph)
-        construct_graphs = set()
+        all_added = 0
         SPARQLQueryHelper = get_query_helper_cls()
-        for a in applicable_nodes:
-            for c in self._constructs:
-                init_bindings = {}
-                found_this = SPARQLQueryHelper.bind_this_regex.search(c)
-                if found_this:
-                    init_bindings['this'] = a
-                c = self._qh.apply_prefixes(c)
-                results = data_graph.query(c, initBindings=init_bindings)
-                if results.type != "CONSTRUCT":
-                    raise ReportableRuntimeError("Query executed by a SHACL SPARQLRule must be CONSTRUCT query.")
-                construct_graphs.add(results.graph)
-        for g in construct_graphs:
-            data_graph = clone_graph(g, target_graph=data_graph)
+        iterate_limit = 100
+        while True:
+            if iterate_limit < 1:
+                raise ReportableRuntimeError("Local rule iteration exceeded iteration limit of 100.")
+            iterate_limit -= 1
+            added = 0
+            applicable_nodes = self.filter_conditions(focus_nodes, data_graph)
+            construct_graphs = set()
+            for a in applicable_nodes:
+                for c in self._constructs:
+                    init_bindings = {}
+                    found_this = SPARQLQueryHelper.bind_this_regex.search(c)
+                    if found_this:
+                        init_bindings['this'] = a
+                    c = self._qh.apply_prefixes(c)
+                    results = data_graph.query(c, initBindings=init_bindings)
+                    if results.type != "CONSTRUCT":
+                        raise ReportableRuntimeError("Query executed by a SHACL SPARQLRule must be CONSTRUCT query.")
+                    this_added = False
+                    for i in results.graph:
+                        if i not in data_graph:
+                            this_added = True
+                            # We only need to know at least one triple was added, then break!
+                            break
+                    if this_added:
+                        added += 1
+                        construct_graphs.add(results.graph)
+            if added > 0:
+                for g in construct_graphs:
+                    data_graph = clone_graph(g, target_graph=data_graph)
+                all_added += added
+                if self.iterate:
+                    continue  # Jump up to iterate
+                else:
+                    break  # Don't iterate
+            break  # We've reached a local steady state
+        return all_added

--- a/pyshacl/rules/triple/__init__.py
+++ b/pyshacl/rules/triple/__init__.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
 class TripleRule(SHACLRule):
     __slots__ = ("s", "p", "o")
 
-    def __init__(self, shape: 'Shape', rule_node: 'rdflib.term.Identifier'):
+    def __init__(self, shape: 'Shape', rule_node: 'rdflib.term.Identifier', **kwargs):
         """
 
         :param shape:
@@ -39,7 +39,7 @@ class TripleRule(SHACLRule):
         :param rule_node:
         :type rule_node: rdflib.term.Identifier
         """
-        super(TripleRule, self).__init__(shape, rule_node)
+        super(TripleRule, self).__init__(shape, rule_node, **kwargs)
         my_subject_nodes = set(self.shape.sg.objects(self.node, SH_subject))
         if len(my_subject_nodes) < 1:
             raise RuntimeError("No sh:subject")
@@ -183,13 +183,36 @@ class TripleRule(SHACLRule):
         else:
             raise NotImplementedError("Unsupported expression s, p, or o, in SHACL TripleRule")
 
-    def apply(self, data_graph):
+    def apply(self, data_graph: 'GraphLike') -> int:
         focus_nodes = self.shape.focus_nodes(data_graph)  # uses target nodes to find focus nodes
         applicable_nodes = self.filter_conditions(focus_nodes, data_graph)
-        for a in applicable_nodes:
-            s_set = self.get_nodes_from_node_expression(self.s, a, data_graph)
-            p_set = self.get_nodes_from_node_expression(self.p, a, data_graph)
-            o_set = self.get_nodes_from_node_expression(self.o, a, data_graph)
-            new_triples = itertools.product(s_set, p_set, o_set)
-            for i in iter(new_triples):
-                data_graph.add(i)
+        all_added = 0
+        iterate_limit = 100
+        while True:
+            if iterate_limit < 1:
+                raise ReportableRuntimeError("Local rule iteration exceeded iteration limit of 100.")
+            iterate_limit -= 1
+            added = 0
+            to_add = []
+            for a in applicable_nodes:
+                s_set = self.get_nodes_from_node_expression(self.s, a, data_graph)
+                p_set = self.get_nodes_from_node_expression(self.p, a, data_graph)
+                o_set = self.get_nodes_from_node_expression(self.o, a, data_graph)
+                new_triples = itertools.product(s_set, p_set, o_set)
+                this_added = False
+                for i in iter(new_triples):
+                    if i not in data_graph:
+                        to_add.append(i)
+                        this_added = True
+                if this_added:
+                    added += 1
+            if added > 0:
+                for i in to_add:
+                    data_graph.add(i)
+                all_added += added
+                if self.iterate:
+                    continue  # Jump up to iterate
+                else:
+                    break  # Don't iterate
+            break
+        return all_added

--- a/pyshacl/rules/triple/__init__.py
+++ b/pyshacl/rules/triple/__init__.py
@@ -190,7 +190,7 @@ class TripleRule(SHACLRule):
         iterate_limit = 100
         while True:
             if iterate_limit < 1:
-                raise ReportableRuntimeError("Local rule iteration exceeded iteration limit of 100.")
+                raise ReportableRuntimeError("sh:rule iteration exceeded iteration limit of 100.")
             iterate_limit -= 1
             added = 0
             to_add = []
@@ -201,9 +201,9 @@ class TripleRule(SHACLRule):
                 new_triples = itertools.product(s_set, p_set, o_set)
                 this_added = False
                 for i in iter(new_triples):
-                    if i not in data_graph:
-                        to_add.append(i)
+                    if not this_added and i not in data_graph:
                         this_added = True
+                    to_add.append(i)
                 if this_added:
                     added += 1
             if added > 0:

--- a/test/issues/test_076.py
+++ b/test/issues/test_076.py
@@ -1,0 +1,126 @@
+# -*- coding: utf-8 -*-
+#
+"""
+https://github.com/RDFLib/pySHACL/issues/76
+"""
+import rdflib
+
+from pyshacl import validate
+
+shacl_file_text = '''
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix skos: <http://www.w3.org/2008/05/skos#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix : <http://example.com/issue/076#> .
+
+<http://example.com/issue/076>
+  rdf:type owl:Ontology ;
+  owl:imports <http://datashapes.org/dash> ;
+  sh:declare [
+		sh:prefix "" ;
+		sh:namespace "http://example.com/issue/076#"^^xsd:anyURI ;
+	] .
+
+:TopConceptRule
+	a sh:NodeShape ;
+	sh:property [
+		sh:path skos:topConceptOf ;
+		sh:minCount 1 ;
+	] .
+
+:DepthRule
+	a sh:NodeShape ;
+	sh:targetClass skos:Concept ;
+	sh:rule [
+		a sh:SPARQLRule ;
+		sh:prefixes skos:, : ;
+		sh:order 1 ;
+		sh:condition :TopConceptRule ;
+		sh:construct """
+		    CONSTRUCT {
+				$this :hasDepth 0 .
+			}
+			WHERE {
+			}
+		""" ;
+	] ;
+	sh:rule [
+		a sh:SPARQLRule ;
+		sh:prefixes skos:, : ;
+		sh:order 2 ;
+		sh:construct """
+		    CONSTRUCT {
+				$this :hasDepth ?plusOne .
+			}
+			WHERE {
+				$this skos:broader ?parent .
+				?parent :hasDepth ?depth .
+				bind(?depth + 1 as ?plusOne)
+			}
+		""" ;
+	] .
+'''
+
+data_file_text = """
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2008/05/skos#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix ex: <http://example.com#> .
+
+ex:animalsVocabulary rdf:type skos:ConceptScheme;
+  dct:title "Animals Vocabulary"@en;
+  skos:hasTopConcept ex:animals .
+
+ex:animals rdf:type skos:Concept;
+  skos:prefLabel "animals"@en;
+  skos:inScheme ex:animalsVocabulary;
+  skos:topConceptOf ex:animalsVocabulary .
+
+ex:cat rdf:type skos:Concept;
+  skos:prefLabel "cat"@en;
+  skos:broader ex:animals ;
+  skos:inScheme ex:animalsVocabulary.
+
+ex:wildcat a skos:Concept;
+  skos:inScheme ex:animalsVocabulary;
+  skos:broader ex:cat .
+
+ex:europeanWildcat a skos:Concept;
+  skos:inScheme ex:animalsVocabulary;
+  skos:broader ex:wildcat .
+"""
+
+def test_076_positive():
+    data = rdflib.Graph()
+    data.parse(data=data_file_text, format="turtle")
+    res = validate(data, shacl_graph=shacl_file_text,
+                   data_graph_format='turtle', shacl_graph_format='turtle',
+                   inference='rdfs', inplace=True, advanced=True, iterate_rules=True, debug=True)
+    conforms, graph, string = res
+    find_s = rdflib.URIRef("http://example.com#europeanWildcat")
+    find_p = rdflib.URIRef("http://example.com/issue/076#hasDepth")
+    find_o = rdflib.Literal(3)
+    assert (find_s, find_p, find_o) in data
+
+def test_076_negative():
+    data = rdflib.Graph()
+    data.parse(data=data_file_text, format="turtle")
+    res = validate(data, shacl_graph=shacl_file_text,
+                   data_graph_format='turtle', shacl_graph_format='turtle',
+                   inference='rdfs', inplace=True, advanced=True, iterate_rules=False, debug=True)
+    conforms, graph, string = res
+    find_s = rdflib.URIRef("http://example.com#europeanWildcat")
+    find_p = rdflib.URIRef("http://example.com/issue/076#hasDepth")
+    find_o = rdflib.Literal(3)
+    assert (find_s, find_p, find_o) not in data
+
+if __name__ == "__main__":
+    test_076_positive()
+    test_076_negative()


### PR DESCRIPTION
Add the ability for SHACL rules to operate iteratively.
They repeatedly execute until the data_graph reaches a steady state.

This works on SPARQL Rules, Triple Rules, and JS Rules.
Closes #76