### PR TITLE
Remove dependency on rdflib-jsonld

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ include = [
 
 [tool.poetry.dependencies]
 python = "^3.6.2"  # Compatible python versions must be declared here
-rdflib = ">=5.0.0,<7"
+rdflib = ">=6.0.0,<7"
 owlrl = "^5.2.1"
 rdflib-jsonld = ">=0.4.0,<0.6"
 pyduktape2 = {version="^0.4.1", python=">=3.6", optional=true}

--- a/pyshacl/pyshacl-cli.spec
+++ b/pyshacl/pyshacl-cli.spec
@@ -19,7 +19,6 @@ a = Analysis(
                 'rdflib.plugins',
                 'rdflib',
                 'urllib3',
-                'rdflib_jsonld',
                 'win32com.gen_py',
                 'pkg_resources.py2_warn'
             ],

--- a/pyshacl/rdfutil/load.py
+++ b/pyshacl/rdfutil/load.py
@@ -18,13 +18,6 @@ ConjunctiveLike = Union[rdflib.ConjunctiveGraph, rdflib.Dataset]
 GraphLike = Union[ConjunctiveLike, rdflib.Graph]
 
 
-try:
-    import rdflib_jsonld  # noqa: F401
-
-    has_json_ld = True
-except ImportError:
-    has_json_ld = False
-
 is_windows = platform.system() == "Windows"
 
 
@@ -244,8 +237,6 @@ def load_from_source(
                 source.close()
             source = new_bytes
             source_was_open = False
-        if (rdf_format == "json-ld" or rdf_format == "json") and not has_json_ld:
-            raise RuntimeError("Cannot load a JSON-LD file if rdflib_jsonld is not installed.")
         if rdf_format == 'turtle' or rdf_format == 'n3':
             # SHACL Shapes files and Data files can have extra RDF Metadata in the
             # Top header block, including #BaseURI and #Prefix.

--- a/pyshacl/validate.py
+++ b/pyshacl/validate.py
@@ -11,17 +11,8 @@ from typing import Dict, List, Optional, Set, Tuple, Union
 import owlrl
 import rdflib
 
-from rdflib.util import from_n3
-
-from .extras import check_extra_installed
-from .pytypes import GraphLike
-from .target import apply_target_types, gather_target_types
-
-
-if owlrl.json_ld_available:
-    import rdflib_jsonld  # noqa: F401
-
 from rdflib import BNode, Literal, URIRef
+from rdflib.util import from_n3
 
 from .consts import (
     RDF_object,
@@ -35,9 +26,11 @@ from .consts import (
     SH_ValidationReport,
 )
 from .errors import ReportableRuntimeError, ValidationFailure
+from .extras import check_extra_installed
 from .functions import apply_functions, gather_functions, unapply_functions
 from .inference import CustomRDFSOWLRLSemantics, CustomRDFSSemantics
 from .monkey import apply_patches, rdflib_bool_patch, rdflib_bool_unpatch
+from .pytypes import GraphLike
 from .rdfutil import (
     clone_blank_node,
     clone_graph,
@@ -51,6 +44,7 @@ from .rdfutil import (
 from .rdfutil.load import add_baked_in
 from .rules import apply_rules, gather_rules
 from .shapes_graph import ShapesGraph
+from .target import apply_target_types, gather_target_types
 
 
 log_handler = logging.StreamHandler(stderr)


### PR DESCRIPTION
Closes #93 

Requires https://github.com/RDFLib/OWL-RL/pull/46 to be merged and released first, then needs a `poetry lock`.

Isort reordered some imports in ` pyshacl/validate.py`, I can undo that but as it is right now it should follow the CONTRIBUTING guidelines of the project.