### PR TITLE
Fix typo in cli.py and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,7 @@ optional arguments:
                         Choose a type of inferencing to run against the Data
                         Graph before validating.
   -m, --metashacl       Validate the SHACL Shapes graph against the shacl-
-                        shacl Shapes Graph before before validating the Data
-                        Graph.
+                        shacl Shapes Graph before validating the Data Graph.
   --imports             Allow import of sub-graphs defined in statements with
                         owl:imports.
   -a, --advanced        Enable support for SHACL Advanced Features.

--- a/pyshacl/cli.py
+++ b/pyshacl/cli.py
@@ -54,7 +54,7 @@ parser.add_argument(
     action='store_true',
     default=False,
     help='Validate the SHACL Shapes graph against the shacl-shacl '
-    'Shapes Graph before before validating the Data Graph.',
+    'Shapes Graph before validating the Data Graph.',
 )
 parser.add_argument(
     '-im',

--- a/pyshacl/cli.py
+++ b/pyshacl/cli.py
@@ -53,8 +53,7 @@ parser.add_argument(
     dest='metashacl',
     action='store_true',
     default=False,
-    help='Validate the SHACL Shapes graph against the shacl-shacl '
-    'Shapes Graph before validating the Data Graph.',
+    help='Validate the SHACL Shapes graph against the shacl-shacl Shapes Graph before validating the Data Graph.',
 )
 parser.add_argument(
     '-im',


### PR DESCRIPTION
In case it matters: I applied the README fix by hand, making a guess on the line wrapping.