### PR TITLE
Deduplicate functions during gathering

### DIFF
--- a/pyshacl/functions/__init__.py
+++ b/pyshacl/functions/__init__.py
@@ -2,7 +2,7 @@
 #
 import sys
 
-from typing import TYPE_CHECKING, Set, Sequence, Union
+from typing import TYPE_CHECKING, Dict, Sequence, Union
 
 from pyshacl.consts import (
     RDF_type,
@@ -64,7 +64,7 @@ def gather_functions(shacl_graph: 'ShapesGraph') -> Sequence[Union['SHACLFunctio
         scl_nodes.remove(n)
         js_nodes.add(n)
 
-    all_fns: dict[RDFNode, Union['SHACLFunction', 'SPARQLFunction', 'JSFunction']] = {}
+    all_fns: Dict[RDFNode, Union['SHACLFunction', 'SPARQLFunction', 'JSFunction']] = {}
     if spq_nodes:
         SPQ = getattr(module, 'SPARQLFunction', None)
         if not SPQ:

--- a/pyshacl/functions/__init__.py
+++ b/pyshacl/functions/__init__.py
@@ -2,7 +2,7 @@
 #
 import sys
 
-from typing import TYPE_CHECKING, List, Sequence, Union
+from typing import TYPE_CHECKING, Set, Sequence, Union
 
 from pyshacl.consts import (
     RDF_type,
@@ -14,7 +14,7 @@ from pyshacl.consts import (
     SH_SHACLFunction,
     SH_SPARQLFunction,
 )
-from pyshacl.pytypes import GraphLike
+from pyshacl.pytypes import GraphLike, RDFNode
 
 
 if TYPE_CHECKING:
@@ -64,7 +64,7 @@ def gather_functions(shacl_graph: 'ShapesGraph') -> Sequence[Union['SHACLFunctio
         scl_nodes.remove(n)
         js_nodes.add(n)
 
-    all_fns: List[Union['SHACLFunction', 'SPARQLFunction', 'JSFunction']] = []
+    all_fns: dict[RDFNode, Union['SHACLFunction', 'SPARQLFunction', 'JSFunction']] = {}
     if spq_nodes:
         SPQ = getattr(module, 'SPARQLFunction', None)
         if not SPQ:
@@ -74,7 +74,7 @@ def gather_functions(shacl_graph: 'ShapesGraph') -> Sequence[Union['SHACLFunctio
             setattr(module, 'SPARQLFunction', SPARQLFunction)
             SPQ = SPARQLFunction
         for n in spq_nodes:
-            all_fns.append(SPQ(n, shacl_graph))
+            all_fns[n] = SPQ(n, shacl_graph)
     if scl_nodes:
         SCL = getattr(module, 'SHACLFunction', None)
         if not SCL:
@@ -84,7 +84,7 @@ def gather_functions(shacl_graph: 'ShapesGraph') -> Sequence[Union['SHACLFunctio
             setattr(module, 'SHACLFunction', SHACLFunction)
             SCL = SHACLFunction
         for n in scl_nodes:
-            all_fns.append(SCL(n, shacl_graph))
+            all_fns[n] = SCL(n, shacl_graph)
     if use_JSFunction and js_nodes:
         JSF = getattr(module, 'JSFunction', None)
         if not JSF:
@@ -94,8 +94,8 @@ def gather_functions(shacl_graph: 'ShapesGraph') -> Sequence[Union['SHACLFunctio
             setattr(module, 'JSFunction', JSFunction)
             JSF = JSFunction
         for n in js_nodes:
-            all_fns.append(JSF(n, shacl_graph))
-    return all_fns
+            all_fns[n] = JSF(n, shacl_graph)
+    return list(all_fns.values())
 
 
 def apply_functions(fns: Sequence, data_graph: GraphLike):

--- a/test/issues/test_108.py
+++ b/test/issues/test_108.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+#
+"""
+https://github.com/RDFLib/pySHACL/issues/108
+"""
+from pyshacl import validate
+
+# from DASH
+shacl_file_text = """
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+dash:toString a sh:JSFunction,
+        sh:SPARQLFunction ;
+    rdfs:label "to string" ;
+    dash:cachable true ;
+    rdfs:comment "Returns a literal with datatype xsd:string that has the input value as its string. If the input value is an (URI) resource then its URI will be used." ;
+    sh:jsFunctionName "dash_toString" ;
+    sh:jsLibrary dash:DASHJSLibrary ;
+    sh:labelTemplate "Convert {$arg} to xsd:string" ;
+    sh:parameter [ a sh:Parameter ;
+            sh:description "The input value." ;
+            sh:name "arg" ;
+            sh:nodeKind sh:IRIOrLiteral ;
+            sh:path dash:arg ] ;
+    sh:prefixes <http://datashapes.org/dash> ;
+    sh:returnType xsd:string ;
+    sh:select "SELECT (xsd:string($arg) AS ?result) WHERE { }" .
+"""
+
+def test_108():
+    res = validate(shacl_file_text, advanced=True, js=True)
+    conforms, graph, string = res
+    assert conforms


### PR DESCRIPTION
Documented in #108, returning a list of functions where certain functions (the same node) are listed twice can cause the issue I've documented in https://github.com/RDFLib/rdflib/issues/1492. This PR uses a dictionary to deduplicate those functions during the gather phase, which avoids the issue.

**However**, this only keeps one copy of the function. In the provided test case, only the `JSFunction` object of the function is kept, not the `SPARQLFunction` object. This *may* cause issues, but I am not familiar enough with the internals to know what the impact may be.