### PR TITLE
Remove printing environment vars when running CLI with -j flag

### DIFF
--- a/pyshacl/extras/__init__.py
+++ b/pyshacl/extras/__init__.py
@@ -17,7 +17,6 @@ dev_mode = False
 
 @lru_cache()
 def check_extra_installed(extra_name: str):
-    print(os.environ)
     if dev_mode:
         return True
     check_name = "pyshacl[" + extra_name + "]"

--- a/pyshacl/extras/__init__.py
+++ b/pyshacl/extras/__init__.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 #
-import os
-
 from functools import lru_cache
 from warnings import warn
 


### PR DESCRIPTION
When running the commandline (using the `-j` flag) given in the readme the CLI prints all environment variables due to a stray print statement in the `extras` module. I assume this is a leftover of some debugging session...?

I would appreciate if you would accept this PR to remove the print statement.

