### PR TITLE
Add way to report non-conformance on sh:Warning but not sh:Info

### DIFF
--- a/pyshacl/cli.py
+++ b/pyshacl/cli.py
@@ -89,6 +89,13 @@ parser.add_argument(
 )
 parser.add_argument('--abort', dest='abort', action='store_true', default=False, help='Abort on first invalid data.')
 parser.add_argument(
+    '--allow-infos',
+    dest='allow_infos',
+    action='store_true',
+    default=False,
+    help='Shapes marked with severity of Info will not cause result to be invalid.',
+)
+parser.add_argument(
     '-w',
     '--allow-warnings',
     dest='allow_warnings',
@@ -177,6 +184,8 @@ def main():
             validator_kwargs['iterate_rules'] = True
     if args.abort:
         validator_kwargs['abort_on_first'] = True
+    if args.allow_infos:
+        validator_kwargs['allow_infos'] = True
     if args.allow_warnings:
         validator_kwargs['allow_warnings'] = True
     if args.shacl_file_format:

--- a/pyshacl/shape.py
+++ b/pyshacl/shape.py
@@ -427,6 +427,7 @@ class Shape(object):
             ]
         ] = None,
         abort_on_first: Optional[bool] = False,
+        allow_infos: Optional[bool] = False,
         allow_warnings: Optional[bool] = False,
         _evaluation_path: Optional[List] = None,
     ):
@@ -476,6 +477,11 @@ class Shape(object):
         focus_value_nodes = self.value_nodes(target_graph, focus)
         filter_reports: bool = False
         allow_conform: bool = False
+        if allow_infos:
+            if self.severity == SH_Info:
+                allow_conform = True
+            else:
+                filter_reports = True
         if allow_warnings:
             if self.severity in (SH_Warning, SH_Info):
                 allow_conform = True

--- a/pyshacl/validate.py
+++ b/pyshacl/validate.py
@@ -63,6 +63,7 @@ class Validator(object):
         options_dict.setdefault('use_js', False)
         options_dict.setdefault('iterate_rules', False)
         options_dict.setdefault('abort_on_first', False)
+        options_dict.setdefault('allow_infos', False)
         options_dict.setdefault('allow_warnings', False)
         if 'logger' not in options_dict:
             options_dict['logger'] = logging.getLogger(__name__)
@@ -243,6 +244,7 @@ class Validator(object):
             named_graphs = [the_target_graph]
         reports = []
         abort_on_first: bool = bool(self.options.get("abort_on_first", False))
+        allow_infos: bool = bool(self.options.get("allow_infos", False))
         allow_warnings: bool = bool(self.options.get("allow_warnings", False))
         non_conformant = False
         aborted = False
@@ -252,7 +254,9 @@ class Validator(object):
                 apply_rules(advanced['rules'], g, iterate=iterate_rules)
             try:
                 for s in shapes:
-                    _is_conform, _reports = s.validate(g, abort_on_first=abort_on_first, allow_warnings=allow_warnings)
+                    _is_conform, _reports = s.validate(
+                        g, abort_on_first=abort_on_first, allow_infos=allow_infos, allow_warnings=allow_warnings
+                    )
                     non_conformant = non_conformant or (not _is_conform)
                     reports.extend(_reports)
                     if abort_on_first and non_conformant:
@@ -332,6 +336,7 @@ def validate(
     inference: Optional[str] = None,
     inplace: Optional[bool] = False,
     abort_on_first: Optional[bool] = False,
+    allow_infos: Optional[bool] = False,
     allow_warnings: Optional[bool] = False,
     **kwargs,
 ):
@@ -353,6 +358,8 @@ def validate(
     :type inplace: bool
     :param abort_on_first: Stop evaluating constraints after first violation is found
     :type abort_on_first: bool | None
+    :param allow_infos: Shapes marked with severity of sh:Info will not cause result to be invalid.
+    :type allow_infos: bool | None
     :param allow_warnings: Shapes marked with severity of sh:Warning or sh:Info will not cause result to be invalid.
     :type allow_warnings: bool | None
     :param kwargs:
@@ -409,6 +416,7 @@ def validate(
                 'inference': inference,
                 'inplace': inplace,
                 'abort_on_first': abort_on_first,
+                'allow_infos': allow_infos,
                 'allow_warnings': allow_warnings,
                 'advanced': advanced,
                 'iterate_rules': iterate_rules,


### PR DESCRIPTION
This patch series lets `sh:Info` be reported with a `sh:conforms true` result.  In some settings, users might accept `sh:Info`, but not `sh:Warning`.

At the time of this writing, I did not see any tests that exercised the `--allow-warnings` flag.  I appreciate a test might be desired before merging, and also that the extra argument to `validate()` is positional and thus might cause a backwards-compatibility issue.  If there is a next-major-version branch this PR should be filed against instead, please let me know.