### PR TITLE
remove value_node_to_string() to fix Issue 133

### DIFF
--- a/pyshacl/constraints/core/string_based_constraints.py
+++ b/pyshacl/constraints/core/string_based_constraints.py
@@ -48,16 +48,6 @@ class StringBasedConstraintBase(ConstraintComponent):
     def constraint_name(cls):
         raise NotImplementedError()
 
-    @classmethod
-    def value_node_to_string(cls, v):
-        if isinstance(v, rdflib.Literal):
-            v_string = str(v.value)
-        elif isinstance(v, rdflib.URIRef):
-            v_string = str(v)
-        else:
-            v_string = str(v)
-        return v_string
-
     def _evaluate_string_rule(self, r, target_graph, f_v_dict):
         raise NotImplementedError()
 
@@ -134,8 +124,7 @@ class MinLengthConstraintComponent(StringBasedConstraintBase):
                     # blank nodes cannot pass minLen validation
                     pass
                 else:
-                    v_string = self.value_node_to_string(v)
-                    flag = len(v_string) >= min_len
+                    flag = len(str(v)) >= min_len
                 if not flag:
                     non_conformant = True
                     rept = self.make_v_result(target_graph, f, value_node=v)
@@ -196,8 +185,7 @@ class MaxLengthConstraintComponent(StringBasedConstraintBase):
                     # blank nodes cannot pass minLen validation
                     pass
                 else:
-                    v_string = self.value_node_to_string(v)
-                    flag = len(v_string) <= max_len
+                    flag = len(str(v)) <= max_len
                 if not flag:
                     non_conformant = True
                     rept = self.make_v_result(target_graph, f, value_node=v)
@@ -276,10 +264,9 @@ class PatternConstraintComponent(StringBasedConstraintBase):
                     # blank nodes cannot pass pattern validation
                     pass
                 else:
-                    v_string = self.value_node_to_string(v)
-                    match = re_matcher.match(v_string)
+                    match = re_matcher.match(str(v))
                     if not match:
-                        match = re_matcher.search(v_string)
+                        match = re_matcher.search(str(v))
                 if not match:
                     non_conformant = True
                     rept = self.make_v_result(target_graph, f, value_node=v)

--- a/test/issues/test_133.py
+++ b/test/issues/test_133.py
@@ -1,0 +1,81 @@
+"""
+https://github.com/RDFLib/pySHACL/issues/133
+"""
+from pyshacl import validate
+from rdflib import Graph
+from rdflib.namespace import RDF, SH
+
+
+def test_issue133():
+    shacl_graph = Graph().parse(
+        data=r"""
+            @prefix geo: <http://www.opengis.net/ont/geosparql#> .
+            @prefix sh: <http://www.w3.org/ns/shacl#> .
+            @base <http://www.opengis.net/def/geosparql/validator/> .
+
+
+            <S16-wkt-content>
+                a sh:NodeShape ;
+                sh:property <S16-wkt-content-sub-start> ;
+                sh:targetSubjectsOf geo:asWKT ;
+            .
+
+            <S16-wkt-content-sub-start>
+                a sh:PropertyShape ;
+                sh:path geo:asWKT ;
+                sh:pattern "^\\s*$|^\\s*(P|C|S|L|T|<)" ;
+                sh:flags "i" ;
+                sh:message "The content of an RDF literal with an incoming geo:asWKT relation must conform to a well-formed WKT string, as defined by its official specification (Simple Features Access)."@en ;
+            .
+        """,
+        format="turtle"
+    )
+
+    data_graph = Graph().parse(
+        data="""
+            @prefix geo: <http://www.opengis.net/ont/geosparql#> .
+
+            <https://example.com/geometry-a>
+                geo:asWKT "POINT (153.084231 -27.322738)"^^geo:wktLiteral ;
+            .
+
+            <https://example.com/geometry-b>
+                geo:asWKT "xPOINT (153.084231 -27.322738)"^^geo:wktLiteral ;
+            .
+
+            <https://example.com/geometry-c>
+                geo:asWKT "(153.084231 -27.322738)"^^geo:wktLiteral ;
+            .
+
+            <https://example.com/geometry-d>
+                geo:asWKT "     POINT (153.084231 -27.322738)"^^geo:wktLiteral ;
+            .
+
+            <https://example.com/geometry-e>
+                geo:asWKT "     "^^geo:wktLiteral ;
+            .
+
+            <https://example.com/geometry-f>
+                geo:asWKT ""^^geo:wktLiteral ;
+            .
+        """,
+        format="turtle"
+    )
+
+    conforms, results_graph, s = validate(data_graph, shacl_graph=shacl_graph, meta_shacl=True)
+    assert not conforms, "This validation should fail"
+
+    # check that only b & c fail
+    expected_fails = sorted([
+        "https://example.com/geometry-b",
+        "https://example.com/geometry-c"
+    ])
+
+    actual_fails = sorted([str(o) for o in results_graph.objects(None, SH.focusNode)])
+
+    assert expected_fails == actual_fails, f"The expected fails are {expected_fails} " \
+                                           f"but the actual fails are {actual_fails}"
+
+
+if __name__ == "__main__":
+    test_issue133()


### PR DESCRIPTION
The function `value_node_to_string()` called `str(v.value)` for a Literal else `str(v)` but this was returning None for Literal which meant pySHACL couldn't validate `sh:pattern` matches.

The fix was also to call `str(v)` for Literal thereby making the function return the same output regardless of input type, just:

```python
def value_node_to_string(v):
    return str(v)
```

So I've removed the function and included a test. After removal, all other tests pass without any further code alterations.

Fixes #133 