### PR TITLE
Add Dockerfile. Resolve #135.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.*
+*.png
+*.svg
+Dockerfile
+.dockerignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3-slim
+WORKDIR /app
+COPY . .
+RUN pip install poetry
+RUN poetry install --no-dev
+ENTRYPOINT ["poetry","run","pyshacl"]

--- a/README.md
+++ b/README.md
@@ -213,6 +213,14 @@ This will output ``pyshacl.exe`` in the ``dist`` directory in ``src/pyshacl``.
 You can now run the pySHACL Command Line utility via ``pyshacl.exe``.
 See above for the pySHACL command line util usage instructions.
 
+## Docker
+
+After checking out the repository, you can build a Docker image with `docker build . -t pyshacl`.
+You can now run pySHACL inside a container but you need to mount the data you want to validate.
+For example, to validate `graph.ttl` against `shacl.ttl`, run :
+```bash
+docker run --rm --mount type=bind,src=`pwd`,dst=/data pyshacl -s /data/shacl.ttl /data/graph.ttl
+```
 
 ## Compatibility
 PySHACL is a Python3 library. For best compatibility use Python v3.7 or greater. Python3 v3.6 or below is _**not supported**_ and this library _**does not work**_ on Python v2.7.x or below.


### PR DESCRIPTION
Tested locally as `docker build . -t pyshacl` and then `cd` into a copy of <https://github.com/hitontology/ontology/> and then:
 ```bash
docker run --rm --mount type=bind,src=`pwd`,dst=/data pyshacl -s /data/shacl.ttl /data/ontology.ttl
```
* test and benchmark need to exist or the build fails even with `poetry install --no-dev`  so they can't be put into .dockerignore
* I didn't specify versions for poetry and only major version 3 for python but no version after the dot to reduce the update burden but you may want to use constrain dependency versions instead. However that seems to be the same workflow as a developer would use, as in install the latest poetry and the latest python.
* all other dependencies should follow the normal rules, as specified in poetry.lock