### PR TITLE
Migrate from distutils to packaging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ python = "^3.7.0"  # Compatible python versions must be declared here
 rdflib = ">=6.1.1,<8"
 owlrl = ">=6.0.2,<7"
 prettytable = "^2.2.1"
+packaging = ">=21.3"
 rdflib-jsonld = { version=">=0.4.0,<0.6", optional=true}
 pyduktape2 = {version="^0.4.1", optional=true}
 flake8 = {version="^3.8.0", optional=true}

--- a/pyshacl/monkey/__init__.py
+++ b/pyshacl/monkey/__init__.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
 
-from packaging.version import Version
-
 import rdflib
 
+from packaging.version import Version
 from rdflib import plugin, store
 
 

--- a/pyshacl/monkey/__init__.py
+++ b/pyshacl/monkey/__init__.py
@@ -1,17 +1,17 @@
 # -*- coding: utf-8 -*-
 
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 import rdflib
 
 from rdflib import plugin, store
 
 
-RDFLIB_VERSION = LooseVersion(rdflib.__version__)
-RDFLIB_421 = LooseVersion("4.2.1")
-RDFLIB_500 = LooseVersion("5.0.0")
-RDFLIB_600 = LooseVersion("6.0.0")
-RDFLIB_602 = LooseVersion("6.0.2")
+RDFLIB_VERSION = Version(rdflib.__version__)
+RDFLIB_421 = Version("4.2.1")
+RDFLIB_500 = Version("5.0.0")
+RDFLIB_600 = Version("6.0.0")
+RDFLIB_602 = Version("6.0.2")
 
 
 def rdflib_bool_patch():

--- a/test/issues/test_146.py
+++ b/test/issues/test_146.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+"""
+https://github.com/RDFLib/pySHACL/issues/146
+"""
+
+import warnings
+
+
+def test_146() -> None:
+    # Ensure that importing pyshacl triggers no warnings.
+    with warnings.catch_warnings(record=True) as warning_context:
+        # Cause all warnings to always be triggered.
+        warnings.simplefilter("always")
+        # Import pyshacl, which should not trigger any warnings
+        import pyshacl
+        # Verify some things
+        assert len(warning_context) == 0
+
+
+if __name__ == "__main__":
+    test_146()


### PR DESCRIPTION
The distutils package has been deprecated in Python 3.10 and will go
away in Python 3.12. Remove an unsightly deprecation warning by
migrating away from distutils now. Switch from
distutils.version.LooseVersion to packaging.version.Version. No other
code changes appear to be necessary.

Include a unit test to verify that pySHACL imports without raising any
warnings.

Closes #146 