### PR TITLE
Use SHACL graph to help find focus nodes for targetClass

### DIFF
--- a/pyshacl/shape.py
+++ b/pyshacl/shape.py
@@ -326,7 +326,7 @@ class Shape(object):
         :return:
         """
         # 'unified' takes into account any class structure defined in the
-        # shape graph for the purposes of finding target classes
+        # shape graph for the purposes of finding instances of the target class
         unified = data_graph + self.sg.graph
         (target_nodes, target_classes, implicit_classes, target_objects_of, target_subjects_of) = self.target()
         if self._advanced:

--- a/test/issues/test_148.py
+++ b/test/issues/test_148.py
@@ -1,0 +1,74 @@
+import rdflib
+import pyshacl
+
+model_data = """
+@prefix ex: <urn:ex#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+
+ex:A a ex:SubSubClass .
+"""
+
+shapes_and_ontology_data = """
+@prefix ex: <urn:ex#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+ex:Class a owl:Class .
+ex:SubClass a owl:Class ;
+    rdfs:subClassOf ex:Class .
+ex:SubSubClass a owl:Class ;
+    rdfs:subClassOf ex:SubClass .
+
+ex:FailedRule a sh:NodeShape ;
+    sh:targetClass ex:Class ;
+    sh:rule [
+        a sh:TripleRule ;
+        sh:object ex:Inferred ;
+        sh:predicate ex:hasProperty ;
+        sh:subject sh:this ;
+    ] .
+"""
+
+
+def test_ruleTargetClass_twograph():
+    shape_g = rdflib.Graph().parse(data=shapes_and_ontology_data, format='turtle')
+    data_g = rdflib.Graph().parse(data=model_data, format='turtle')
+
+    conforms, results_graph, results_text = pyshacl.validate(
+        data_graph=data_g, shacl_graph=shape_g, advanced=True
+    )
+    assert conforms
+    assert (rdflib.URIRef("urn:ex#A"), rdflib.URIRef("urn:ex#hasProperty"), rdflib.URIRef("urn:ex#Inferred")) in data_g
+
+def test_ruleTargetClass_twograph_ontgraph():
+    shape_g = rdflib.Graph().parse(data=shapes_and_ontology_data, format='turtle')
+    data_g = rdflib.Graph().parse(data=model_data, format='turtle')
+
+    conforms, results_graph, results_text = pyshacl.validate(
+        data_graph=data_g, ont_graph=shape_g, advanced=True
+    )
+    assert conforms
+    assert (rdflib.URIRef("urn:ex#A"), rdflib.URIRef("urn:ex#hasProperty"), rdflib.URIRef("urn:ex#Inferred")) in data_g
+
+def test_ruleTargetClass_twograph_ont_and_shape_graph():
+    shape_g = rdflib.Graph().parse(data=shapes_and_ontology_data, format='turtle')
+    data_g = rdflib.Graph().parse(data=model_data, format='turtle')
+
+    conforms, results_graph, results_text = pyshacl.validate(
+        data_graph=data_g, shacl_graph=shape_g, ont_graph=shape_g, advanced=True
+    )
+    assert conforms
+    assert (rdflib.URIRef("urn:ex#A"), rdflib.URIRef("urn:ex#hasProperty"), rdflib.URIRef("urn:ex#Inferred")) in data_g
+
+def test_ruleTargetClass_onegraph():
+    data_g = rdflib.Graph().parse(data=shapes_and_ontology_data, format='turtle').parse(data=model_data, format='turtle')
+
+    conforms, results_graph, results_text = pyshacl.validate(
+        data_graph=data_g, advanced=True
+    )
+    assert conforms
+    assert (rdflib.URIRef("urn:ex#A"), rdflib.URIRef("urn:ex#hasProperty"), rdflib.URIRef("urn:ex#Inferred")) in data_g


### PR DESCRIPTION
Addresses #148 as a start. Probably not the ideal fix for 2 reasons:
1. doesn't use the ontology graph (though weird things seem to happen when ontology graph *and* shape graph are provided...inference doesn't happen at all! Not sure why that happens but I think this is out of scope for #148)
2. the fix feels hacky and wasteful -- we create a temporary graph that is the union of the shape graph and the data graph inside `shape.focus_nodes`. Is there a better way?

However, I wanted to create the fix to demonstrate what the fix may look like