### PR TITLE
Use sh:detail for sh:NodeConstraintComponent

### DIFF
--- a/pyshacl/constraints/core/shape_based_constraints.py
+++ b/pyshacl/constraints/core/shape_based_constraints.py
@@ -8,7 +8,14 @@ from warnings import warn
 import rdflib
 
 from pyshacl.constraints.constraint_component import ConstraintComponent
-from pyshacl.consts import SH, SH_node, SH_NodeConstraintComponent, SH_property, SH_PropertyConstraintComponent
+from pyshacl.consts import (
+    SH,
+    SH_node,
+    SH_NodeConstraintComponent,
+    SH_property,
+    SH_PropertyConstraintComponent,
+    SH_detail,
+)
 from pyshacl.errors import (
     ConstraintLoadError,
     ConstraintLoadWarning,
@@ -18,6 +25,7 @@ from pyshacl.errors import (
 )
 from pyshacl.pytypes import GraphLike
 from pyshacl.rdfutil import stringify_node
+from textwrap import indent
 
 SH_QualifiedValueCountConstraintComponent = SH.QualifiedValueConstraintComponent
 SH_QualifiedMaxCountConstraintComponent = SH.QualifiedMaxCountConstraintComponent
@@ -143,10 +151,11 @@ class NodeConstraintComponent(ConstraintComponent):
 
     def make_generic_messages(self, datagraph: GraphLike, focus_node, value_node) -> List[rdflib.Literal]:
         if len(self.node_shapes) < 2:
-            m = "Value does not conform to Shape {}".format(stringify_node(self.shape.sg.graph, self.node_shapes[0]))
+            m = "Value does not conform to Shape {}.".format(stringify_node(self.shape.sg.graph, self.node_shapes[0]))
         else:
             rules = "', '".join(stringify_node(self.shape.sg.graph, c) for c in self.node_shapes)
-            m = "Value does not conform to every Shape in ('{}')".format(rules)
+            m = "Value does not conform to every Shape in ('{}').".format(rules)
+        m += " See details for more information."
         return [rdflib.Literal(m)]
 
     def evaluate(self, target_graph: GraphLike, focus_value_nodes: Dict, _evaluation_path: List):
@@ -181,23 +190,24 @@ class NodeConstraintComponent(ConstraintComponent):
                 raise ReportableRuntimeError(
                     "Shape pointed to by sh:node does not exist or is not a well-formed SHACL NodeShape."
                 )
-            upstream_reports = []
             for f, value_nodes in focus_value_nodes.items():
                 for v in value_nodes:
                     _is_conform, _r = node_shape.validate(target_graph, focus=v, _evaluation_path=_evaluation_path[:])
-                    if len(_r):
-                        upstream_reports.extend(_r)
-                    # ignore the fails from the node, create our own fail
+                    # Create a failure for this constraint component if any failures exist
                     if (not _is_conform) or len(_r) > 0:
                         _non_conformant = True
-                        rept = self.make_v_result(target_graph, f, value_node=v)
-                        _reports.append(rept)
-            if len(upstream_reports) > 0 and self.shape.sg.debug:
-                self.shape.logger.debug(
-                    "sh:node constraint reports will be ignored and not passed to the parent Node:"
-                )
-                for v_str, v_node, v_parts in _r:
-                    self.shape.logger.debug(v_str)
+                        rept_text, rept_node, rept_triples = self.make_v_result(target_graph, f, value_node=v)
+                        # Nest the others underneath via sh:detail
+                        rept_text = f"{rept_text}\tDetails:\n"
+                        for (text_sub, node_sub, triples_sub) in _r:
+                            # Add text of validation result in nested details section
+                            rept_text += indent(text_sub, "\t\t")
+                            # Add a triple connecting the new validation result to the
+                            # validation result for the nested node
+                            rept_triples.append((rept_node, SH_detail, node_sub))
+                            # Extend the triples in the report with the ones from the nested result
+                            rept_triples.extend(triples_sub)
+                        _reports.append((rept_text, rept_node, rept_triples))
             return _non_conformant, _reports
 
         for n_shape in self.node_shapes:

--- a/pyshacl/consts.py
+++ b/pyshacl/consts.py
@@ -120,6 +120,7 @@ SH_optional = SH.optional
 SH_js = SH.js
 SH_jsFunctionName = SH.jsFunctionName
 SH_jsLibrary = SH.jsLibrary
+SH_detail = SH.detail
 
 # For env var truth comparisons
 env_truths = ("t", "T", "y", "Y", "1", "True", "true", "TRUE", "yes", "YES", 1, True)

--- a/test/test_sh_details.py
+++ b/test/test_sh_details.py
@@ -1,0 +1,63 @@
+import pyshacl
+from rdflib.namespace import SH
+
+
+test_node_ttl = """\
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix ex: <http://example.org/> .
+
+
+ex:PersonShape
+  a sh:NodeShape ;
+  sh:targetClass ex:Person ;
+  sh:node ex:Shape1 ;
+.
+
+ex:Shape1
+  a sh:NodeShape ;
+  sh:node ex:Shape2 ;
+  sh:property [
+    a sh:PropertyShape ;
+    sh:path ex:familyName ;
+    sh:datatype xsd:string ;
+    sh:minCount 1 ;
+  ] ;
+.
+
+ex:Shape2
+  a sh:NodeShape ;
+  sh:property [
+    a sh:PropertyShape ;
+    sh:path ex:givenName ;
+    sh:datatype xsd:string ;
+    sh:minCount 1 ;
+  ] ;
+.
+
+ex:Person1
+  a ex:Person ;
+.
+"""
+
+
+def test_node_details():
+    conforms, graph, text = pyshacl.validate(test_node_ttl, data_graph_format="turtle")
+    assert not conforms
+    top_results = set(graph.objects(None, SH.result))
+    assert len(top_results) == 1
+    top_result = top_results.pop()
+    details = set(graph.objects(top_result, SH.detail))
+    assert len(details) == 2
+    for r in details:
+        details = set(graph.objects(r, SH.detail))
+        if len(details) == 0:
+            source_1 = r
+        elif len(details) == 1:
+            mid_result = r
+    assert source_1
+    assert mid_result
+    assert (source_1, SH.sourceConstraintComponent, SH.MinCountConstraintComponent) in graph
+    assert (mid_result, SH.detail / SH.sourceConstraintComponent, SH.MinCountConstraintComponent) in graph


### PR DESCRIPTION
# Overview
The SHACL spec states that [`sh:detail`](https://www.w3.org/TR/shacl/#results-detail) may be used to provide further details about a validation result. Previously, pySHACL would ignore (the word used in the comments) the failures generated for `sh:node` and create a new validation error such that the details never made it into the final validation report. This attaches those validation results to the newly generated error via `sh:detail` so they are available for use in the final validation report if it is desired to take advantage of them.

Specifically, this PR contains the following modifications:
- The addition of any nested validation errors for `sh:node` via `sh:detail` in the result graph
- The addition of the human readable text representation of any nested validation errors for `sh:node` indented under the violation of the NodeConstraintComponent
- Addition of a test to verify these changes are working as expected
- Modification of the `clean_validation_reports` function to filter out `sh:detail` such that the DASH and SHT test suites continue to pass

# Example
Below are examples of how the validation reports are changed by this PR as a diff compared to the report before these modifications are applied. The graph used to generate these reports is the one used in the added test.

## Graph-Based Report
Note that some triples in the serialization have been reordered from rdflib's default serialization behavior to make it more readable for the sake of this example.
```diff
 @prefix ex: <http://example.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 [] a sh:ValidationReport ;
     sh:conforms false ;
     sh:result [ a sh:ValidationResult ;
             sh:focusNode ex:Person1 ;
-            sh:resultMessage "Value does not conform to Shape ex:Shape1" ;
+            sh:resultMessage "Value does not conform to Shape ex:Shape1. See details for more information." ;
             sh:resultSeverity sh:Violation ;
             sh:sourceConstraintComponent sh:NodeConstraintComponent ;
             sh:sourceShape ex:Person ;
-            sh:value ex:Person1 ] .
+            sh:value ex:Person1 ;
+            sh:detail [ a sh:ValidationResult ;
+                    sh:focusNode ex:Person1 ;
+                    sh:resultMessage "Less than 1 values on ex:Person1->ex:familyName" ;
+                    sh:resultPath ex:familyName ;
+                    sh:resultSeverity sh:Violation ;
+                    sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
+                    sh:sourceShape [ a sh:PropertyShape ;
+                            sh:datatype xsd:string ;
+                            sh:minCount 1 ;
+                            sh:path ex:familyName ] ],
+                [ a sh:ValidationResult ;
+                    sh:focusNode ex:Person1 ;
+                    sh:resultMessage "Value does not conform to Shape ex:Shape2. See details for more information." ;
+                    sh:resultSeverity sh:Violation ;
+                    sh:sourceConstraintComponent sh:NodeConstraintComponent ;
+                    sh:sourceShape ex:Shape1 ;
+                    sh:value ex:Person1 ;
+                    sh:detail [ a sh:ValidationResult ;
+                            sh:focusNode ex:Person1 ;
+                            sh:resultMessage "Less than 1 values on ex:Person1->ex:givenName" ;
+                            sh:resultPath ex:givenName ;
+                            sh:resultSeverity sh:Violation ;
+                            sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
+                            sh:sourceShape [ a sh:PropertyShape ;
+                                    sh:datatype xsd:string ;
+                                    sh:minCount 1 ;
+                                    sh:path ex:givenName ] ] ] ] .
```

# Text-Based Report
```diff
 Validation Report
 Conforms: False
 Results (1):
 Constraint Violation in NodeConstraintComponent (http://www.w3.org/ns/shacl#NodeConstraintComponent):
         Severity: sh:Violation
         Source Shape: ex:Person
         Focus Node: ex:Person1
         Value Node: ex:Person1
-        Message: Value does not conform to Shape ex:Shape1
+        Message: Value does not conform to Shape ex:Shape1. See details for more information.
+        Details:
+                Constraint Violation in MinCountConstraintComponent (http://www.w3.org/ns/shacl#MinCountConstraintComponent):
+                        Severity: sh:Violation
+                        Source Shape: [ rdf:type sh:PropertyShape ; sh:datatype xsd:string ; sh:minCount Literal("1", datatype=xsd:integer) ; sh:path ex:familyName ]
+                        Focus Node: ex:Person1
+                        Result Path: ex:familyName
+                        Message: Less than 1 values on ex:Person1->ex:familyName
+                Constraint Violation in NodeConstraintComponent (http://www.w3.org/ns/shacl#NodeConstraintComponent):
+                        Severity: sh:Violation
+                        Source Shape: ex:Shape1
+                        Focus Node: ex:Person1
+                        Value Node: ex:Person1
+                        Message: Value does not conform to Shape ex:Shape2. See details for more information.
+                        Details:
+                                Constraint Violation in MinCountConstraintComponent (http://www.w3.org/ns/shacl#MinCountConstraintComponent):
+                                        Severity: sh:Violation
+                                        Source Shape: [ rdf:type sh:PropertyShape ; sh:datatype xsd:string ; sh:minCount Literal("1", datatype=xsd:integer) ; sh:path ex:givenName ]
+                                        Focus Node: ex:Person1
+                                        Result Path: ex:givenName
+                                        Message: Less than 1 values on ex:Person1->ex:givenName
```