### PR TITLE
Enable parameter values for SPARQL-based Constraint Components that are not literals to be added to generated messages correctly

### DIFF
--- a/pyshacl/helper/sparql_query_helper.py
+++ b/pyshacl/helper/sparql_query_helper.py
@@ -42,7 +42,7 @@ class SPARQLQueryHelper(object):
         r"SELECT[\s\(\)\$\?\a-z]*\{[^\}]*SELECT\s+((?:(?:[\?\$]\w+\s+)|(?:\*\s+))+)", flags=re.M | re.I
     )
     has_as_var_regex = re.compile(r"[^\w]+AS[\s]+[\$\?](\w+)", flags=re.M | re.I)
-    find_msg_subs = re.compile(r"({[\$\?](.+)})", flags=re.M)
+    find_msg_subs = re.compile(r"({[\$\?]([^{}]+)})", flags=re.M)
 
     def __init__(self, shape, node, select_text, parameters=None, messages=None, deactivated=False):
         self._shape = None
@@ -119,7 +119,7 @@ class SPARQLQueryHelper(object):
                 except KeyError:
                     replacer = re.compile(r"{[\$\?]" + variable + r"}", flags=re.M)
                     var_replacers[variable] = replacer
-                m_val = replacer.sub(str(param_map[variable].value), m_val, 1)
+                m_val = replacer.sub(str(param_map[variable]), m_val, 1)
             bound_messages.add(rdflib.Literal(m_val, lang=m.language, datatype=m.datatype))
         self.bound_messages = bound_messages
 

--- a/test/issues/test_199.py
+++ b/test/issues/test_199.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+#
+"""
+https://github.com/RDFLib/pySHACL/issues/199
+"""
+import rdflib
+from rdflib.namespace import SH
+import pyshacl
+
+
+shapes_data = '''\
+@prefix ex: <https://example.com#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+
+
+ex:TestConstraintComponent
+  a sh:ConstraintComponent ;
+  sh:parameter [
+    sh:path ex:theValue ;
+  ] ;
+  sh:validator [
+    a sh:SPARQLAskValidator ;
+    sh:message "{$this}: {$theValue}" ;
+    sh:ask """
+      ASK {
+        FILTER ($this != $this)  # Always create a validation report for this constraint component
+      }""" ;
+  ] .
+
+ex:TestClass1
+  a owl:Class ;
+  a sh:NodeShape ;
+  ex:theValue "Literal" .
+ex:TestClass2
+  a owl:Class ;
+  a sh:NodeShape ;
+  ex:theValue ex:SomeURI .
+ex:TestClass3
+  a owl:Class ;
+  a sh:NodeShape ;
+  ex:theValue _:bnode .
+'''
+
+
+def test_199():
+    shape_g = rdflib.Graph().parse(data=shapes_data, format='turtle')
+    data_g = rdflib.Graph().parse(data="""
+    @prefix ex: <https://example.com#> .
+    @prefix sh: <http://www.w3.org/ns/shacl#> .
+
+    ex:A a ex:TestClass1 .
+    ex:B a ex:TestClass2 .
+    ex:C a ex:TestClass3 .
+    """, format='turtle')
+
+    conforms, results_graph, results_text = pyshacl.validate(
+        data_g, shacl_graph=shape_g, debug=True,
+    )
+    assert not conforms
+    assert len(list(results_graph[:SH.result])) == 3
+
+
+if __name__ == "__main__":
+    exit(test_199())


### PR DESCRIPTION
This fixes #199. It includes two changes:
- The string representation of parameter values are used instead of trying to access the `value` attribute that only works for Literals.
- The regex used to find parameters is modified because the previous expression would only match one parameter substitution. If multiple were present, it would match one incorrect string. For example, if your template was `{$this} does not have value {$value}`, the regular expression would match `$this} does not have value {$value` instead of `$this` and `$value`. Note that the regex is still a bit fragile if whitespace is involved.

A test is also added to verify both these issues are resolved.