### PR TITLE
build: pass pip keyring related environment variables

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -215,6 +215,10 @@ passenv =
     DRONE_COMMIT_AUTHOR_EMAIL
     DRONE_COMMIT
     HAS_COVERALLS
+    DBUS_SESSION_BUS_ADDRESS
+    PIP_KEYRING_PROVIDER
+    PIP_FORCE_KEYRING
+    PYTHON_KEYRING_BACKEND
 skip_install = true
 allowlist_externals = python3, ls, pwd, env, poetry
 setenv =


### PR DESCRIPTION
On Linux, I need to have either `DBUS_SESSION_BUS_ADDRESS` or some other keyring related environment variable set to avoid keyring related errors. This patch adds these environment variables to the list of environment variables that tox passes through to the test environment.

For the relevant documentation, see:

- `DBUS_SESSION_BUS_ADDRESS`: https://stackoverflow.com/questions/52264818/runtimeerror-unable-to-initialize-secretservice-environment-variable-dbus-sess
- `PIP_KEYRING_PROVIDER` and `PIP_FORCE_KEYRING`: https://pip.pypa.io/en/stable/topics/authentication/
- `PYTHON_KEYRING_BACKEND`: https://github.com/jaraco/keyring#disabling-keyring