### PR TITLE
Make importlib-metadata pin a lower bound

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ prettytable = [
     {version=">=3.7.0", python = ">=3.12"}
 ]
 packaging = ">=21.3"
-importlib-metadata = {version="4.13", python = "<3.11"}
+importlib-metadata = {version=">=4.13", python = "<3.11"}
 pyduktape2 = {version="^0.4.6", optional=true}
 sanic = {version=">=22.12, <23", optional=true} #For the HTTP service
 sanic-ext = {version=">=23.3, <23.6", optional=true} #For the HTTP service


### PR DESCRIPTION
Thanks for maintaining `pySHACL`, and congratulations on `0.24.0` :tada: !

This PR makes the new pin on `importlib-metadata` viable in a wider range of environments: at least in the [`conda-forge` downstream](https://github.com/conda-forge/pyshacl-feedstock/pull/52), other packages in the test environment pull in `importlib-metadata 6.x`, and pass with this patch. 

As `python 3.7` is also dropped in the `conda-forge` ecosystem, there may be _other_ new pins that are challenging, but we won't be able to find them.