### PR TITLE
Remove -Likes

### DIFF
--- a/pyshacl/constraints/advanced/__init__.py
+++ b/pyshacl/constraints/advanced/__init__.py
@@ -7,13 +7,14 @@ https://www.w3.org/TR/shacl-af/#ExpressionConstraintComponent
 import typing
 from typing import Dict, List
 
+import rdflib
 from rdflib import Literal
 
 from pyshacl.constraints.constraint_component import ConstraintComponent
 from pyshacl.consts import SH, SH_message
 from pyshacl.errors import ConstraintLoadError
 from pyshacl.helper.expression_helper import nodes_from_node_expression
-from pyshacl.pytypes import GraphLike, SHACLExecutor
+from pyshacl.pytypes import SHACLExecutor
 
 SH_expression = SH.expression
 SH_ExpressionConstraintComponent = SH.ExpressionConstraintComponent
@@ -42,11 +43,11 @@ class ExpressionConstraint(ConstraintComponent):
     def constraint_name(cls):
         return "ExpressionConstraintComponent"
 
-    def make_generic_messages(self, datagraph: GraphLike, focus_node, value_node) -> List[Literal]:
+    def make_generic_messages(self, datagraph: rdflib.Graph, focus_node, value_node) -> List[Literal]:
         return [Literal("Expression evaluation generated constraint did not return true.")]
 
     def evaluate(
-        self, executor: SHACLExecutor, data_graph: GraphLike, focus_value_nodes: Dict, _evaluation_path: List
+        self, executor: SHACLExecutor, data_graph: rdflib.Graph, focus_value_nodes: Dict, _evaluation_path: List
     ):
         """
         :type executor: SHACLExecutor

--- a/pyshacl/constraints/constraint_component.py
+++ b/pyshacl/constraints/constraint_component.py
@@ -8,6 +8,7 @@ import re
 import typing
 from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Set, Tuple
 
+import rdflib
 from rdflib import BNode, Literal, URIRef
 
 from pyshacl.consts import (
@@ -33,7 +34,7 @@ from pyshacl.consts import (
 )
 from pyshacl.errors import ConstraintLoadError
 from pyshacl.parameter import SHACLParameter
-from pyshacl.pytypes import GraphLike, SHACLExecutor
+from pyshacl.pytypes import SHACLExecutor
 from pyshacl.rdfutil import stringify_node
 
 if TYPE_CHECKING:
@@ -78,11 +79,11 @@ class ConstraintComponent(object, metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def evaluate(
-        self, executor: SHACLExecutor, target_graph: GraphLike, focus_value_nodes: Dict, _evaluation_path: List
+        self, executor: SHACLExecutor, target_graph: rdflib.Graph, focus_value_nodes: Dict, _evaluation_path: List
     ):
         raise NotImplementedError()  # pragma: no cover
 
-    def make_generic_messages(self, datagraph: GraphLike, focus_node, value_node) -> List[Literal]:
+    def make_generic_messages(self, datagraph: rdflib.Graph, focus_node, value_node) -> List[Literal]:
         return []
 
     def __str__(self):
@@ -127,7 +128,7 @@ class ConstraintComponent(object, metaclass=abc.ABCMeta):
 
     def make_v_result_description(
         self,
-        datagraph: GraphLike,
+        datagraph: rdflib.Graph,
         focus_node: 'RDFNode',
         severity: URIRef,
         value_node: Optional['RDFNode'],
@@ -209,7 +210,7 @@ class ConstraintComponent(object, metaclass=abc.ABCMeta):
 
     def make_v_result(
         self,
-        datagraph: GraphLike,
+        datagraph: rdflib.Graph,
         focus_node: 'RDFNode',
         value_node: Optional['RDFNode'] = None,
         result_path: Optional['RDFNode'] = None,

--- a/pyshacl/constraints/core/cardinality_constraints.py
+++ b/pyshacl/constraints/core/cardinality_constraints.py
@@ -4,13 +4,14 @@ https://www.w3.org/TR/shacl/#core-components-count
 """
 from typing import Dict, List
 
+import rdflib
 from rdflib.namespace import XSD
 from rdflib.term import Literal
 
 from pyshacl.constraints.constraint_component import ConstraintComponent
 from pyshacl.consts import SH
 from pyshacl.errors import ConstraintLoadError
-from pyshacl.pytypes import GraphLike, SHACLExecutor
+from pyshacl.pytypes import SHACLExecutor
 from pyshacl.rdfutil import stringify_node
 
 XSD_integer = XSD.integer
@@ -70,7 +71,7 @@ class MinCountConstraintComponent(ConstraintComponent):
     def constraint_name(cls):
         return "MinCountConstraintComponent"
 
-    def make_generic_messages(self, datagraph: GraphLike, focus_node, value_node) -> List[Literal]:
+    def make_generic_messages(self, datagraph: rdflib.Graph, focus_node, value_node) -> List[Literal]:
         p = self.shape.path()
         if p:
             p = stringify_node(self.shape.sg.graph, p)
@@ -82,7 +83,7 @@ class MinCountConstraintComponent(ConstraintComponent):
         return [Literal(m)]
 
     def evaluate(
-        self, executor: SHACLExecutor, target_graph: GraphLike, focus_value_nodes: Dict, _evaluation_path: List
+        self, executor: SHACLExecutor, target_graph: rdflib.Graph, focus_value_nodes: Dict, _evaluation_path: List
     ):
         """
         :type executor: SHACLExecutor
@@ -153,7 +154,7 @@ class MaxCountConstraintComponent(ConstraintComponent):
     def constraint_name(cls):
         return "MaxCountConstraintComponent"
 
-    def make_generic_messages(self, datagraph: GraphLike, focus_node, value_node) -> List[Literal]:
+    def make_generic_messages(self, datagraph: rdflib.Graph, focus_node, value_node) -> List[Literal]:
         p = self.shape.path()
         if p:
             p = stringify_node(self.shape.sg.graph, p)
@@ -165,7 +166,7 @@ class MaxCountConstraintComponent(ConstraintComponent):
         return [Literal(m)]
 
     def evaluate(
-        self, executor: SHACLExecutor, target_graph: GraphLike, focus_value_nodes: Dict, _evaluation_path: List
+        self, executor: SHACLExecutor, target_graph: rdflib.Graph, focus_value_nodes: Dict, _evaluation_path: List
     ):
         """
         :type executor: SHACLExecutor

--- a/pyshacl/constraints/core/logical_constraints.py
+++ b/pyshacl/constraints/core/logical_constraints.py
@@ -10,7 +10,7 @@ import rdflib
 from pyshacl.constraints.constraint_component import ConstraintComponent
 from pyshacl.consts import SH
 from pyshacl.errors import ConstraintLoadError, ReportableRuntimeError, ShapeRecursionWarning, ValidationFailure
-from pyshacl.pytypes import GraphLike, SHACLExecutor
+from pyshacl.pytypes import SHACLExecutor
 from pyshacl.rdfutil import stringify_node
 
 SH_not = SH["not"]
@@ -55,7 +55,7 @@ class NotConstraintComponent(ConstraintComponent):
     def constraint_name(cls):
         return "NotConstraintComponent"
 
-    def make_generic_messages(self, datagraph: GraphLike, focus_node, value_node) -> List[rdflib.Literal]:
+    def make_generic_messages(self, datagraph: rdflib.Graph, focus_node, value_node) -> List[rdflib.Literal]:
         if len(self.not_list) == 1:
             m = f"Node {stringify_node(datagraph, value_node)} conforms to shape {stringify_node(self.shape.sg.graph, self.not_list[0])}"
         else:
@@ -63,7 +63,9 @@ class NotConstraintComponent(ConstraintComponent):
             m = f"Node {stringify_node(datagraph, value_node)} conforms to one or more shapes in {nots_list}"
         return [rdflib.Literal(m)]
 
-    def evaluate(self, executor: SHACLExecutor, datagraph: GraphLike, focus_value_nodes: Dict, _evaluation_path: List):
+    def evaluate(
+        self, executor: SHACLExecutor, datagraph: rdflib.Graph, focus_value_nodes: Dict, _evaluation_path: List
+    ):
         """
         :type executor: SHACLExecutor
         :type datagraph: rdflib.Graph
@@ -158,7 +160,7 @@ class AndConstraintComponent(ConstraintComponent):
     def constraint_name(cls):
         return "AndConstraintComponent"
 
-    def make_generic_messages(self, datagraph: GraphLike, focus_node, value_node) -> List[rdflib.Literal]:
+    def make_generic_messages(self, datagraph: rdflib.Graph, focus_node, value_node) -> List[rdflib.Literal]:
         and_list = " , ".join(
             stringify_node(self.shape.sg.graph, a_c) for a in self.and_list for a_c in self.shape.sg.graph.items(a)
         )
@@ -166,7 +168,7 @@ class AndConstraintComponent(ConstraintComponent):
         return [rdflib.Literal(m)]
 
     def evaluate(
-        self, executor: SHACLExecutor, target_graph: GraphLike, focus_value_nodes: Dict, _evaluation_path: List
+        self, executor: SHACLExecutor, target_graph: rdflib.Graph, focus_value_nodes: Dict, _evaluation_path: List
     ):
         """
         :type executor: SHACLExecutor
@@ -254,7 +256,7 @@ class OrConstraintComponent(ConstraintComponent):
     def constraint_name(cls):
         return "OrConstraintComponent"
 
-    def make_generic_messages(self, datagraph: GraphLike, focus_node, value_node) -> List[rdflib.Literal]:
+    def make_generic_messages(self, datagraph: rdflib.Graph, focus_node, value_node) -> List[rdflib.Literal]:
         or_list = " , ".join(
             stringify_node(self.shape.sg.graph, o_c) for o in self.or_list for o_c in self.shape.sg.graph.items(o)
         )
@@ -264,7 +266,7 @@ class OrConstraintComponent(ConstraintComponent):
         return [rdflib.Literal(m)]
 
     def evaluate(
-        self, executor: SHACLExecutor, target_graph: GraphLike, focus_value_nodes: Dict, _evaluation_path: List
+        self, executor: SHACLExecutor, target_graph: rdflib.Graph, focus_value_nodes: Dict, _evaluation_path: List
     ):
         """
         :type executor: SHACLExecutor
@@ -352,7 +354,7 @@ class XoneConstraintComponent(ConstraintComponent):
     def constraint_name(cls):
         return "XoneConstraintComponent"
 
-    def make_generic_messages(self, datagraph: GraphLike, focus_node, value_node) -> List[rdflib.Literal]:
+    def make_generic_messages(self, datagraph: rdflib.Graph, focus_node, value_node) -> List[rdflib.Literal]:
         xone_list = " , ".join(
             stringify_node(self.shape.sg.graph, a_c) for a in self.xone_nodes for a_c in self.shape.sg.graph.items(a)
         )
@@ -362,7 +364,7 @@ class XoneConstraintComponent(ConstraintComponent):
         return [rdflib.Literal(m)]
 
     def evaluate(
-        self, executor: SHACLExecutor, target_graph: GraphLike, focus_value_nodes: Dict, _evaluation_path: List
+        self, executor: SHACLExecutor, target_graph: rdflib.Graph, focus_value_nodes: Dict, _evaluation_path: List
     ):
         """
         :type executor: SHACLExecutor

--- a/pyshacl/constraints/core/other_constraints.py
+++ b/pyshacl/constraints/core/other_constraints.py
@@ -9,7 +9,7 @@ import rdflib
 from pyshacl.constraints.constraint_component import ConstraintComponent
 from pyshacl.consts import RDFS, SH, RDF_type, SH_property
 from pyshacl.errors import ConstraintLoadError, ReportableRuntimeError
-from pyshacl.pytypes import GraphLike, RDFNode, SHACLExecutor
+from pyshacl.pytypes import RDFNode, SHACLExecutor
 from pyshacl.rdfutil import stringify_node
 
 SH_InConstraintComponent = SH.InConstraintComponent
@@ -61,13 +61,13 @@ class InConstraintComponent(ConstraintComponent):
     def constraint_name(cls):
         return "InConstraintComponent"
 
-    def make_generic_messages(self, datagraph: GraphLike, focus_node, value_node) -> List[rdflib.Literal]:
+    def make_generic_messages(self, datagraph: rdflib.Graph, focus_node, value_node) -> List[rdflib.Literal]:
         list1 = [stringify_node(self.shape.sg.graph, val) for val in self.in_vals]
         m = "Value {} not in list {}".format(stringify_node(datagraph, value_node), list1)
         return [rdflib.Literal(m)]
 
     def evaluate(
-        self, executor: SHACLExecutor, target_graph: GraphLike, focus_value_nodes: Dict, _evaluation_path: List
+        self, executor: SHACLExecutor, target_graph: rdflib.Graph, focus_value_nodes: Dict, _evaluation_path: List
     ):
         """
         :type executor: SHACLExecutor
@@ -140,14 +140,14 @@ class ClosedConstraintComponent(ConstraintComponent):
     def constraint_name(cls):
         return "ClosedConstraintComponent"
 
-    def make_generic_messages(self, datagraph: GraphLike, focus_node, value_node) -> List[rdflib.Literal]:
+    def make_generic_messages(self, datagraph: rdflib.Graph, focus_node, value_node) -> List[rdflib.Literal]:
         m = "Node {} is closed. It cannot have value: {}".format(
             stringify_node(datagraph, focus_node), stringify_node(datagraph, value_node)
         )
         return [rdflib.Literal(m)]
 
     def evaluate(
-        self, executor: SHACLExecutor, target_graph: GraphLike, focus_value_nodes: Dict, _evaluation_path: List
+        self, executor: SHACLExecutor, target_graph: rdflib.Graph, focus_value_nodes: Dict, _evaluation_path: List
     ):
         """
         :type executor: SHACLExecutor
@@ -221,7 +221,7 @@ class HasValueConstraintComponent(ConstraintComponent):
     def constraint_name(cls):
         return "HasValueConstraintComponent"
 
-    def make_generic_messages(self, datagraph: GraphLike, focus_node, value_node) -> List[rdflib.Literal]:
+    def make_generic_messages(self, datagraph: rdflib.Graph, focus_node, value_node) -> List[rdflib.Literal]:
         the_set = [stringify_node(self.shape.sg.graph, s) for s in self.has_value_set]
         p = self.shape.path()
         if p:
@@ -236,7 +236,7 @@ class HasValueConstraintComponent(ConstraintComponent):
         return [rdflib.Literal(m)]
 
     def evaluate(
-        self, executor: SHACLExecutor, target_graph: GraphLike, focus_value_nodes: Dict, _evaluation_path: List
+        self, executor: SHACLExecutor, target_graph: rdflib.Graph, focus_value_nodes: Dict, _evaluation_path: List
     ):
         """
         :type executor: SHACLExecutor

--- a/pyshacl/constraints/core/property_pair_constraints.py
+++ b/pyshacl/constraints/core/property_pair_constraints.py
@@ -9,7 +9,7 @@ import rdflib
 from pyshacl.constraints.constraint_component import ConstraintComponent
 from pyshacl.consts import SH
 from pyshacl.errors import ConstraintLoadError, ReportableRuntimeError
-from pyshacl.pytypes import GraphLike, SHACLExecutor
+from pyshacl.pytypes import SHACLExecutor
 from pyshacl.rdfutil import stringify_node
 
 SH_equals = SH.equals
@@ -52,7 +52,7 @@ class EqualsConstraintComponent(ConstraintComponent):
     def constraint_name(cls):
         return "EqualsConstraintComponent"
 
-    def make_generic_messages(self, datagraph: GraphLike, focus_node, value_node) -> List[rdflib.Literal]:
+    def make_generic_messages(self, datagraph: rdflib.Graph, focus_node, value_node) -> List[rdflib.Literal]:
         if len(self.property_compare_set) < 2:
             m = "Value of {}->{} != {}".format(
                 stringify_node(datagraph, focus_node),
@@ -67,7 +67,7 @@ class EqualsConstraintComponent(ConstraintComponent):
         return [rdflib.Literal(m)]
 
     def evaluate(
-        self, executor: SHACLExecutor, target_graph: GraphLike, focus_value_nodes: Dict, _evaluation_path: List
+        self, executor: SHACLExecutor, target_graph: rdflib.Graph, focus_value_nodes: Dict, _evaluation_path: List
     ):
         """
         :type executor: SHACLExecutor
@@ -134,7 +134,7 @@ class DisjointConstraintComponent(ConstraintComponent):
     def constraint_name(cls):
         return "DisjointConstraintComponent"
 
-    def make_generic_messages(self, datagraph: GraphLike, focus_node, value_node) -> List[rdflib.Literal]:
+    def make_generic_messages(self, datagraph: rdflib.Graph, focus_node, value_node) -> List[rdflib.Literal]:
         if len(self.property_compare_set) < 2:
             m = "Value of {}->{} == {}".format(
                 stringify_node(datagraph, focus_node),
@@ -149,7 +149,7 @@ class DisjointConstraintComponent(ConstraintComponent):
         return [rdflib.Literal(m)]
 
     def evaluate(
-        self, executor: SHACLExecutor, target_graph: GraphLike, focus_value_nodes: Dict, _evaluation_path: List
+        self, executor: SHACLExecutor, target_graph: rdflib.Graph, focus_value_nodes: Dict, _evaluation_path: List
     ):
         """
         :type executor: SHACLExecutor
@@ -218,7 +218,7 @@ class LessThanConstraintComponent(ConstraintComponent):
     def constraint_name(cls):
         return "LessThanConstraintComponent"
 
-    def make_generic_messages(self, datagraph: GraphLike, focus_node, value_node) -> List[rdflib.Literal]:
+    def make_generic_messages(self, datagraph: rdflib.Graph, focus_node, value_node) -> List[rdflib.Literal]:
         if len(self.property_compare_set) < 2:
             m = "Value of {}->{} <= {}".format(
                 stringify_node(datagraph, focus_node),
@@ -233,7 +233,7 @@ class LessThanConstraintComponent(ConstraintComponent):
         return [rdflib.Literal(m)]
 
     def evaluate(
-        self, executor: SHACLExecutor, target_graph: GraphLike, focus_value_nodes: Dict, _evaluation_path: List
+        self, executor: SHACLExecutor, target_graph: rdflib.Graph, focus_value_nodes: Dict, _evaluation_path: List
     ):
         """
         :type executor: SHACLExecutor
@@ -326,7 +326,7 @@ class LessThanOrEqualsConstraintComponent(ConstraintComponent):
     def constraint_name(cls):
         return "LessThanOrEqualsConstraintComponent"
 
-    def make_generic_messages(self, datagraph: GraphLike, focus_node, value_node) -> List[rdflib.Literal]:
+    def make_generic_messages(self, datagraph: rdflib.Graph, focus_node, value_node) -> List[rdflib.Literal]:
         if len(self.property_compare_set) < 2:
             m = "Value of {}->{} < {}".format(
                 stringify_node(datagraph, focus_node),
@@ -341,7 +341,7 @@ class LessThanOrEqualsConstraintComponent(ConstraintComponent):
         return [rdflib.Literal(m)]
 
     def evaluate(
-        self, executor: SHACLExecutor, target_graph: GraphLike, focus_value_nodes: Dict, _evaluation_path: List
+        self, executor: SHACLExecutor, target_graph: rdflib.Graph, focus_value_nodes: Dict, _evaluation_path: List
     ):
         """
         :type executor: SHACLExecutor

--- a/pyshacl/constraints/core/shape_based_constraints.py
+++ b/pyshacl/constraints/core/shape_based_constraints.py
@@ -2,7 +2,6 @@
 """
 https://www.w3.org/TR/shacl/#core-components-shape
 """
-from dataclasses import dataclass
 from textwrap import indent
 from typing import Dict, List
 from warnings import warn
@@ -77,7 +76,7 @@ class PropertyConstraintComponent(ConstraintComponent):
     ):
         """
         Entrypoint for constraint evaluation.
-        :type executor: dataclass
+        :type executor: SHACLExecutor
         :type target_graph: rdflib.Graph
         :type focus_value_nodes: dict
         :type _evaluation_path: list

--- a/pyshacl/constraints/core/shape_based_constraints.py
+++ b/pyshacl/constraints/core/shape_based_constraints.py
@@ -24,7 +24,7 @@ from pyshacl.errors import (
     ShapeRecursionWarning,
     ValidationFailure,
 )
-from pyshacl.pytypes import GraphLike, SHACLExecutor
+from pyshacl.pytypes import SHACLExecutor
 from pyshacl.rdfutil import stringify_node
 
 SH_QualifiedValueCountConstraintComponent = SH.QualifiedValueConstraintComponent
@@ -68,11 +68,11 @@ class PropertyConstraintComponent(ConstraintComponent):
     def constraint_name(cls):
         return "PropertyConstraintComponent"
 
-    def make_generic_messages(self, datagraph: GraphLike, focus_node, value_node) -> List[rdflib.Literal]:
+    def make_generic_messages(self, datagraph: rdflib.Graph, focus_node, value_node) -> List[rdflib.Literal]:
         raise NotImplementedError("A Property Constraint Component should not be able to generate its own message.")
 
     def evaluate(
-        self, executor: SHACLExecutor, target_graph: GraphLike, focus_value_nodes: Dict, _evaluation_path: List
+        self, executor: SHACLExecutor, target_graph: rdflib.Graph, focus_value_nodes: Dict, _evaluation_path: List
     ):
         """
         Entrypoint for constraint evaluation.
@@ -156,7 +156,7 @@ class NodeConstraintComponent(ConstraintComponent):
     def constraint_name(cls):
         return "NodeConstraintComponent"
 
-    def make_generic_messages(self, datagraph: GraphLike, focus_node, value_node) -> List[rdflib.Literal]:
+    def make_generic_messages(self, datagraph: rdflib.Graph, focus_node, value_node) -> List[rdflib.Literal]:
         if len(self.node_shapes) < 2:
             m = "Value does not conform to Shape {}.".format(stringify_node(self.shape.sg.graph, self.node_shapes[0]))
         else:
@@ -166,7 +166,7 @@ class NodeConstraintComponent(ConstraintComponent):
         return [rdflib.Literal(m)]
 
     def evaluate(
-        self, executor: SHACLExecutor, target_graph: GraphLike, focus_value_nodes: Dict, _evaluation_path: List
+        self, executor: SHACLExecutor, target_graph: rdflib.Graph, focus_value_nodes: Dict, _evaluation_path: List
     ):
         """
         :type executor: SHACLExecutor
@@ -317,7 +317,7 @@ class QualifiedValueShapeConstraintComponent(ConstraintComponent):
     def constraint_name(cls):
         return "QualifiedValueShapeConstraintComponent"
 
-    def make_generic_messages(self, datagraph: GraphLike, focus_node, value_node) -> List[rdflib.Literal]:
+    def make_generic_messages(self, datagraph: rdflib.Graph, focus_node, value_node) -> List[rdflib.Literal]:
         # TODO:
         #  Implement default message for QualifiedValueConstraint (seems messy)
         shapes_string = ",".join(stringify_node(self.shape.sg.graph, s) for s in self.value_shapes)
@@ -331,7 +331,7 @@ class QualifiedValueShapeConstraintComponent(ConstraintComponent):
         return [rdflib.Literal(f"Focus node does not conform to shape{count_message}: {shapes_string}")]
 
     def evaluate(
-        self, executor: SHACLExecutor, target_graph: GraphLike, focus_value_nodes: Dict, _evaluation_path: List
+        self, executor: SHACLExecutor, target_graph: rdflib.Graph, focus_value_nodes: Dict, _evaluation_path: List
     ):
         """
         :type executor: SHACLExecutor

--- a/pyshacl/constraints/core/shape_based_constraints.py
+++ b/pyshacl/constraints/core/shape_based_constraints.py
@@ -83,7 +83,6 @@ class PropertyConstraintComponent(ConstraintComponent):
         """
         reports: List[Dict] = []
         non_conformant = False
-        shape = self.shape
 
         # Shortcut, when there are no value nodes, don't check for recursion, don't validate and exit early
         value_node_count = 0
@@ -177,7 +176,6 @@ class NodeConstraintComponent(ConstraintComponent):
         """
         reports: List[Dict] = []
         non_conformant = False
-        shape = self.shape
 
         # Shortcut, when there are no value nodes, don't check for recursion, don't validate and exit early
         value_node_count = 0
@@ -343,7 +341,6 @@ class QualifiedValueShapeConstraintComponent(ConstraintComponent):
         """
         reports: List[Dict] = []
         non_conformant = False
-        shape = self.shape
 
         # Shortcut, when there are no value nodes, don't check for recursion, don't validate and exit early
         value_node_count = 0

--- a/pyshacl/constraints/core/string_based_constraints.py
+++ b/pyshacl/constraints/core/string_based_constraints.py
@@ -11,7 +11,7 @@ from rdflib.namespace import XSD
 from pyshacl.constraints.constraint_component import ConstraintComponent
 from pyshacl.consts import RDF, SH, XSD_WHOLE_INTEGERS
 from pyshacl.errors import ConstraintLoadError, ReportableRuntimeError
-from pyshacl.pytypes import GraphLike, SHACLExecutor
+from pyshacl.pytypes import SHACLExecutor
 from pyshacl.rdfutil import stringify_node
 
 RDF_langString = RDF.langString
@@ -67,7 +67,7 @@ class StringBasedConstraintBase(ConstraintComponent):
         raise NotImplementedError()
 
     def evaluate(
-        self, executor: SHACLExecutor, target_graph: GraphLike, focus_value_nodes: Dict, _evaluation_path: List
+        self, executor: SHACLExecutor, target_graph: rdflib.Graph, focus_value_nodes: Dict, _evaluation_path: List
     ):
         """
         :type executor: SHACLExecutor
@@ -139,7 +139,7 @@ class MinLengthConstraintComponent(StringBasedConstraintBase):
     def constraint_name(cls):
         return "MinLengthConstraintComponent"
 
-    def make_generic_messages(self, datagraph: GraphLike, focus_node, value_node) -> List[rdflib.Literal]:
+    def make_generic_messages(self, datagraph: rdflib.Graph, focus_node, value_node) -> List[rdflib.Literal]:
         m = "String length not >= {}".format(stringify_node(datagraph, self.string_rules[0]))
         return [rdflib.Literal(m)]
 
@@ -219,7 +219,7 @@ class MaxLengthConstraintComponent(StringBasedConstraintBase):
     def constraint_name(cls):
         return "MaxLengthConstraintComponent"
 
-    def make_generic_messages(self, datagraph: GraphLike, focus_node, value_node) -> List[rdflib.Literal]:
+    def make_generic_messages(self, datagraph: rdflib.Graph, focus_node, value_node) -> List[rdflib.Literal]:
         m = "String length not <= {}".format(stringify_node(datagraph, self.string_rules[0]))
         return [rdflib.Literal(m)]
 
@@ -287,7 +287,7 @@ class PatternConstraintComponent(StringBasedConstraintBase):
     def constraint_name(cls):
         return "PatternConstraintComponent"
 
-    def make_generic_messages(self, datagraph: GraphLike, focus_node, value_node) -> List[rdflib.Literal]:
+    def make_generic_messages(self, datagraph: rdflib.Graph, focus_node, value_node) -> List[rdflib.Literal]:
         if len(self.string_rules) < 2:
             m = "Value does not match pattern '{}'".format(str(self.string_rules[0].value))
         else:
@@ -365,7 +365,7 @@ class LanguageInConstraintComponent(StringBasedConstraintBase):
     def constraint_name(cls):
         return "LanguageInConstraintComponent"
 
-    def make_generic_messages(self, datagraph: GraphLike, focus_node, value_node) -> List[rdflib.Literal]:
+    def make_generic_messages(self, datagraph: rdflib.Graph, focus_node, value_node) -> List[rdflib.Literal]:
         m = "String language is not in {}".format(stringify_node(datagraph, self.string_rules[0]))
         return [rdflib.Literal(m)]
 
@@ -459,7 +459,7 @@ class UniqueLangConstraintComponent(StringBasedConstraintBase):
     def constraint_name(cls):
         return "UniqueLangConstraintComponent"
 
-    def make_generic_messages(self, datagraph: GraphLike, focus_node, value_node) -> List[rdflib.Literal]:
+    def make_generic_messages(self, datagraph: rdflib.Graph, focus_node, value_node) -> List[rdflib.Literal]:
         return [rdflib.Literal("More than one String shares the same Language")]
 
     def _evaluate_string_rule(self, is_unique_lang, target_graph, f_v_dict):

--- a/pyshacl/constraints/core/value_constraints.py
+++ b/pyshacl/constraints/core/value_constraints.py
@@ -27,7 +27,7 @@ from pyshacl.consts import (
     SH_nodeKind,
 )
 from pyshacl.errors import ConstraintLoadError
-from pyshacl.pytypes import GraphLike, SHACLExecutor
+from pyshacl.pytypes import SHACLExecutor
 from pyshacl.rdfutil import stringify_node
 
 RDF_langString = RDF.langString
@@ -77,7 +77,7 @@ class ClassConstraintComponent(ConstraintComponent):
     def constraint_name(cls):
         return "ClassConstraintComponent"
 
-    def make_generic_messages(self, datagraph: GraphLike, focus_node, value_node) -> List[Literal]:
+    def make_generic_messages(self, datagraph: rdflib.Graph, focus_node, value_node) -> List[Literal]:
         if len(self.class_rules) < 2:
             m = "Value does not have class {}".format(stringify_node(self.shape.sg.graph, self.class_rules[0]))
         else:
@@ -86,7 +86,7 @@ class ClassConstraintComponent(ConstraintComponent):
         return [Literal(m)]
 
     def evaluate(
-        self, executor: SHACLExecutor, target_graph: GraphLike, focus_value_nodes: Dict, _evaluation_path: List
+        self, executor: SHACLExecutor, target_graph: rdflib.Graph, focus_value_nodes: Dict, _evaluation_path: List
     ):
         """
         :type executor: SHACLExecutor
@@ -164,12 +164,12 @@ class DatatypeConstraintComponent(ConstraintComponent):
     def constraint_name(cls):
         return "DatatypeConstraintComponent"
 
-    def make_generic_messages(self, datagraph: GraphLike, focus_node, value_node) -> List[Literal]:
+    def make_generic_messages(self, datagraph: rdflib.Graph, focus_node, value_node) -> List[Literal]:
         m = "Value is not Literal with datatype {}".format(stringify_node(self.shape.sg.graph, self.datatype_rule))
         return [Literal(m)]
 
     def evaluate(
-        self, executor: SHACLExecutor, target_graph: GraphLike, focus_value_nodes: Dict, _evaluation_path: List
+        self, executor: SHACLExecutor, target_graph: rdflib.Graph, focus_value_nodes: Dict, _evaluation_path: List
     ):
         """
         :type executor: SHACLExecutor
@@ -272,12 +272,12 @@ class NodeKindConstraintComponent(ConstraintComponent):
     def constraint_name(cls):
         return "NodeKindConstraintComponent"
 
-    def make_generic_messages(self, datagraph: GraphLike, focus_node, value_node) -> List[Literal]:
+    def make_generic_messages(self, datagraph: rdflib.Graph, focus_node, value_node) -> List[Literal]:
         m = "Value is not of Node Kind {}".format(stringify_node(self.shape.sg.graph, self.nodekind_rule))
         return [Literal(m)]
 
     def evaluate(
-        self, executor: SHACLExecutor, target_graph: GraphLike, focus_value_nodes: Dict, _evaluation_path: List
+        self, executor: SHACLExecutor, target_graph: rdflib.Graph, focus_value_nodes: Dict, _evaluation_path: List
     ):
         """
         :type executor: SHACLExecutor

--- a/pyshacl/constraints/core/value_range_constraints.py
+++ b/pyshacl/constraints/core/value_range_constraints.py
@@ -10,7 +10,7 @@ import rdflib
 from pyshacl.constraints.constraint_component import ConstraintComponent
 from pyshacl.consts import SH
 from pyshacl.errors import ConstraintLoadError, ReportableRuntimeError
-from pyshacl.pytypes import GraphLike, SHACLExecutor
+from pyshacl.pytypes import SHACLExecutor
 from pyshacl.rdfutil import stringify_node
 from pyshacl.rdfutil.compare import compare_literal
 
@@ -52,7 +52,7 @@ class MinExclusiveConstraintComponent(ConstraintComponent):
     def constraint_name(cls):
         return "MinExclusiveConstraintComponent"
 
-    def make_generic_messages(self, datagraph: GraphLike, focus_node, value_node) -> List[rdflib.Literal]:
+    def make_generic_messages(self, datagraph: rdflib.Graph, focus_node, value_node) -> List[rdflib.Literal]:
         if len(self.min_vals) < 2:
             m = "Value is not > {}".format(stringify_node(self.shape.sg.graph, self.min_vals[0]))
         else:
@@ -61,7 +61,7 @@ class MinExclusiveConstraintComponent(ConstraintComponent):
         return [rdflib.Literal(m)]
 
     def evaluate(
-        self, executor: SHACLExecutor, target_graph: GraphLike, focus_value_nodes: Dict, _evaluation_path: List
+        self, executor: SHACLExecutor, target_graph: rdflib.Graph, focus_value_nodes: Dict, _evaluation_path: List
     ):
         """
         :type executor: SHACLExecutor
@@ -142,7 +142,7 @@ class MinInclusiveConstraintComponent(ConstraintComponent):
     def constraint_name(cls):
         return "MinInclusiveConstraintComponent"
 
-    def make_generic_messages(self, datagraph: GraphLike, focus_node, value_node) -> List[rdflib.Literal]:
+    def make_generic_messages(self, datagraph: rdflib.Graph, focus_node, value_node) -> List[rdflib.Literal]:
         if len(self.min_vals) < 2:
             m = "Value is not >= {}".format(stringify_node(self.shape.sg.graph, self.min_vals[0]))
         else:
@@ -151,7 +151,7 @@ class MinInclusiveConstraintComponent(ConstraintComponent):
         return [rdflib.Literal(m)]
 
     def evaluate(
-        self, executor: SHACLExecutor, target_graph: GraphLike, focus_value_nodes: Dict, _evaluation_path: List
+        self, executor: SHACLExecutor, target_graph: rdflib.Graph, focus_value_nodes: Dict, _evaluation_path: List
     ):
         """
         :type executor: SHACLExecutor
@@ -232,7 +232,7 @@ class MaxExclusiveConstraintComponent(ConstraintComponent):
     def constraint_name(cls):
         return "MaxExclusiveConstraintComponent"
 
-    def make_generic_messages(self, datagraph: GraphLike, focus_node, value_node) -> List[rdflib.Literal]:
+    def make_generic_messages(self, datagraph: rdflib.Graph, focus_node, value_node) -> List[rdflib.Literal]:
         if len(self.max_vals) < 2:
             m = "Value is not < {}".format(stringify_node(self.shape.sg.graph, self.max_vals[0]))
         else:
@@ -241,7 +241,7 @@ class MaxExclusiveConstraintComponent(ConstraintComponent):
         return [rdflib.Literal(m)]
 
     def evaluate(
-        self, executor: SHACLExecutor, target_graph: GraphLike, focus_value_nodes: Dict, _evaluation_path: List
+        self, executor: SHACLExecutor, target_graph: rdflib.Graph, focus_value_nodes: Dict, _evaluation_path: List
     ):
         """
         :type executor: SHACLExecutor
@@ -322,7 +322,7 @@ class MaxInclusiveConstraintComponent(ConstraintComponent):
     def constraint_name(cls):
         return "MaxInclusiveConstraintComponent"
 
-    def make_generic_messages(self, datagraph: GraphLike, focus_node, value_node) -> List[rdflib.Literal]:
+    def make_generic_messages(self, datagraph: rdflib.Graph, focus_node, value_node) -> List[rdflib.Literal]:
         if len(self.max_vals) < 2:
             m = "Value is not <= {}".format(stringify_node(self.shape.sg.graph, self.max_vals[0]))
         else:
@@ -331,7 +331,7 @@ class MaxInclusiveConstraintComponent(ConstraintComponent):
         return [rdflib.Literal(m)]
 
     def evaluate(
-        self, executor: SHACLExecutor, target_graph: GraphLike, focus_value_nodes: Dict, _evaluation_path: List
+        self, executor: SHACLExecutor, target_graph: rdflib.Graph, focus_value_nodes: Dict, _evaluation_path: List
     ):
         """
         :type executor: SHACLExecutor

--- a/pyshacl/constraints/sparql/sparql_based_constraint_components.py
+++ b/pyshacl/constraints/sparql/sparql_based_constraint_components.py
@@ -11,7 +11,7 @@ from pyshacl.constraints.constraint_component import ConstraintComponent, Custom
 from pyshacl.consts import SH, RDF_type, SH_ask, SH_ConstraintComponent, SH_message, SH_select
 from pyshacl.errors import ConstraintLoadError, ValidationFailure
 from pyshacl.helper import get_query_helper_cls
-from pyshacl.pytypes import GraphLike, SHACLExecutor
+from pyshacl.pytypes import SHACLExecutor
 
 if typing.TYPE_CHECKING:
     from pyshacl.shape import Shape
@@ -55,11 +55,11 @@ class BoundShapeValidatorComponent(ConstraintComponent):
     def constraint_name(cls):
         return "ConstraintComponent"
 
-    def make_generic_messages(self, datagraph: GraphLike, focus_node, value_node) -> List[rdflib.Literal]:
+    def make_generic_messages(self, datagraph: rdflib.Graph, focus_node, value_node) -> List[rdflib.Literal]:
         return [rdflib.Literal("Parameterised SHACL Query generated constraint validation reports.")]
 
     def evaluate(
-        self, executor: SHACLExecutor, target_graph: GraphLike, focus_value_nodes: Dict, _evaluation_path: List
+        self, executor: SHACLExecutor, target_graph: rdflib.Graph, focus_value_nodes: Dict, _evaluation_path: List
     ):
         """
         :type executor: SHACLExecutor

--- a/pyshacl/constraints/sparql/sparql_based_constraints.py
+++ b/pyshacl/constraints/sparql/sparql_based_constraints.py
@@ -10,7 +10,7 @@ from pyshacl.constraints.constraint_component import ConstraintComponent
 from pyshacl.consts import SH, SH_deactivated, SH_message, SH_select
 from pyshacl.errors import ConstraintLoadError, ValidationFailure
 from pyshacl.helper import get_query_helper_cls
-from pyshacl.pytypes import GraphLike, SHACLExecutor
+from pyshacl.pytypes import SHACLExecutor
 
 SH_sparql = SH.sparql
 SH_SPARQLConstraintComponent = SH.SPARQLConstraintComponent
@@ -89,7 +89,7 @@ class SPARQLBasedConstraint(ConstraintComponent):
         return "SPARQLConstraintComponent"
 
     def evaluate(
-        self, executor: SHACLExecutor, target_graph: GraphLike, focus_value_nodes: Dict, _evaluation_path: List
+        self, executor: SHACLExecutor, target_graph: rdflib.Graph, focus_value_nodes: Dict, _evaluation_path: List
     ):
         """
         :type executor: SHACLExecutor

--- a/pyshacl/extras/js/constraint.py
+++ b/pyshacl/extras/js/constraint.py
@@ -3,12 +3,13 @@
 import typing
 from typing import Dict, List
 
+import rdflib
 from rdflib import Literal
 
 from pyshacl.constraints import ConstraintComponent
 from pyshacl.consts import SH, SH_js, SH_message
 from pyshacl.errors import ConstraintLoadError
-from pyshacl.pytypes import GraphLike, SHACLExecutor
+from pyshacl.pytypes import SHACLExecutor
 
 from .js_executable import JSExecutable
 
@@ -77,11 +78,11 @@ class JSConstraint(ConstraintComponent):
     def constraint_name(cls):
         return "JSConstraint"
 
-    def make_generic_messages(self, datagraph: GraphLike, focus_node, value_node) -> List[Literal]:
+    def make_generic_messages(self, datagraph: rdflib.Graph, focus_node, value_node) -> List[Literal]:
         return [Literal("Javascript Function generated constraint validation reports.")]
 
     def evaluate(
-        self, executor: SHACLExecutor, data_graph: GraphLike, focus_value_nodes: Dict, _evaluation_path: List
+        self, executor: SHACLExecutor, data_graph: rdflib.Graph, focus_value_nodes: Dict, _evaluation_path: List
     ):
         """
         :type executor: SHACLExecutor

--- a/pyshacl/extras/js/constraint_component.py
+++ b/pyshacl/extras/js/constraint_component.py
@@ -3,13 +3,14 @@
 import typing
 from typing import Any, Dict, List, Tuple, Union
 
+import rdflib
 from rdflib import Literal
 
 from pyshacl.constraints import ConstraintComponent
 from pyshacl.constraints.constraint_component import CustomConstraintComponent
 from pyshacl.consts import SH, SH_ConstraintComponent, SH_message
 from pyshacl.errors import ConstraintLoadError, ReportableRuntimeError, ValidationFailure
-from pyshacl.pytypes import GraphLike, SHACLExecutor
+from pyshacl.pytypes import SHACLExecutor
 
 from .js_executable import JSExecutable
 
@@ -73,11 +74,11 @@ class BoundShapeJSValidatorComponent(ConstraintComponent):
     def constraint_name(cls):
         return "ConstraintComponent"
 
-    def make_generic_messages(self, datagraph: GraphLike, focus_node, value_node) -> List[Literal]:
+    def make_generic_messages(self, datagraph: rdflib.Graph, focus_node, value_node) -> List[Literal]:
         return [Literal("Parameterised Javascript Function generated constraint validation reports.")]
 
     def evaluate(
-        self, executor: SHACLExecutor, data_graph: GraphLike, focus_value_nodes: Dict, _evaluation_path: List
+        self, executor: SHACLExecutor, data_graph: rdflib.Graph, focus_value_nodes: Dict, _evaluation_path: List
     ):
         """
         :type executor: SHACLExecutor

--- a/pyshacl/extras/js/rules.py
+++ b/pyshacl/extras/js/rules.py
@@ -2,6 +2,8 @@
 #
 import typing
 
+import rdflib
+
 from pyshacl.consts import SH
 from pyshacl.errors import ReportableRuntimeError
 from pyshacl.rules.shacl_rule import SHACLRule
@@ -9,7 +11,7 @@ from pyshacl.rules.shacl_rule import SHACLRule
 from .js_executable import JSExecutable
 
 if typing.TYPE_CHECKING:
-    from pyshacl.pytypes import GraphLike, SHACLExecutor
+    from pyshacl.pytypes import SHACLExecutor
     from pyshacl.shape import Shape
     from pyshacl.shapes_graph import ShapesGraph
 
@@ -24,7 +26,7 @@ class JSRule(SHACLRule):
         shapes_graph: 'ShapesGraph' = shape.sg
         self.js_exe = JSExecutable(shapes_graph, rule_node)
 
-    def apply(self, data_graph: 'GraphLike') -> int:
+    def apply(self, data_graph: rdflib.Graph) -> int:
         focus_nodes = self.shape.focus_nodes(data_graph)  # uses target nodes to find focus nodes
         all_added = 0
         iterate_limit = 100

--- a/pyshacl/extras/js/target.py
+++ b/pyshacl/extras/js/target.py
@@ -4,6 +4,7 @@ import typing
 from typing import Dict, List
 from warnings import warn
 
+import rdflib
 from rdflib import URIRef
 
 from pyshacl.consts import SH_JSTargetType
@@ -13,7 +14,7 @@ from pyshacl.target import BoundSHACLTargetType, SHACLTargetType
 from .js_executable import JSExecutable
 
 if typing.TYPE_CHECKING:
-    from pyshacl.pytypes import GraphLike, SHACLExecutor
+    from pyshacl.pytypes import SHACLExecutor
     from pyshacl.shape import Shape
     from pyshacl.shapes_graph import ShapesGraph
 
@@ -47,7 +48,7 @@ class BoundJSTargetType(BoundSHACLTargetType):
         return SH_JSTargetType
 
     def evaluate(
-        self, executor: 'SHACLExecutor', target_graph: 'GraphLike', focus_value_nodes: Dict, _evaluation_path: List
+        self, executor: 'SHACLExecutor', target_graph: rdflib.Graph, focus_value_nodes: Dict, _evaluation_path: List
     ):
         """
         :type executor: SHACLExecutor

--- a/pyshacl/functions/__init__.py
+++ b/pyshacl/functions/__init__.py
@@ -3,6 +3,8 @@
 import sys
 from typing import TYPE_CHECKING, Dict, Sequence, Union
 
+import rdflib
+
 from pyshacl.consts import (
     RDF_type,
     SH_ask,
@@ -13,7 +15,7 @@ from pyshacl.consts import (
     SH_SHACLFunction,
     SH_SPARQLFunction,
 )
-from pyshacl.pytypes import GraphLike, RDFNode, SHACLExecutor
+from pyshacl.pytypes import RDFNode, SHACLExecutor
 
 if TYPE_CHECKING:
     from pyshacl.extras.js.function import JSFunction  # noqa F401
@@ -99,11 +101,11 @@ def gather_functions(
     return list(all_fns.values())
 
 
-def apply_functions(executor: SHACLExecutor, fns: Sequence, data_graph: GraphLike):
+def apply_functions(executor: SHACLExecutor, fns: Sequence, data_graph: rdflib.Graph):
     for f in fns:
         f.apply(data_graph)
 
 
-def unapply_functions(fns: Sequence, data_graph: GraphLike):
+def unapply_functions(fns: Sequence, data_graph: rdflib.Graph):
     for f in fns:
         f.unapply(data_graph)

--- a/pyshacl/functions/shacl_function.py
+++ b/pyshacl/functions/shacl_function.py
@@ -3,6 +3,7 @@
 import typing
 from typing import Dict, List
 
+import rdflib
 from rdflib import XSD, Literal
 from rdflib.plugins.sparql.operators import register_custom_function, unregister_custom_function
 from rdflib.plugins.sparql.sparql import SPARQLError
@@ -13,7 +14,6 @@ from ..helper import get_query_helper_cls
 from ..parameter import SHACLParameter
 
 if typing.TYPE_CHECKING:
-    from ..pytypes import GraphLike
     from ..shapes_graph import ShapesGraph
 
 
@@ -145,7 +145,7 @@ class SPARQLFunction(SHACLFunction):
         else:
             return self.execute_select(g, init_bindings)
 
-    def execute_select(self, g: 'GraphLike', init_bindings: Dict):
+    def execute_select(self, g: rdflib.Graph, init_bindings: Dict):
         s = self._qh.apply_prefixes(self.select)
         results = g.query(s, initBindings=init_bindings)
         if results.type != "SELECT" or results.vars is None:
@@ -158,7 +158,7 @@ class SPARQLFunction(SHACLFunction):
         result = results.bindings[0]
         return result[rvar]
 
-    def execute_ask(self, g: 'GraphLike', init_bindings: Dict):
+    def execute_ask(self, g: rdflib.Graph, init_bindings: Dict):
         a = self._qh.apply_prefixes(self.ask)
         results = g.query(a, initBindings=init_bindings)
         if results.type != "ASK":

--- a/pyshacl/helper/expression_helper.py
+++ b/pyshacl/helper/expression_helper.py
@@ -24,7 +24,7 @@ from pyshacl.consts import (
 from pyshacl.errors import ReportableRuntimeError, ShapeLoadError
 
 if TYPE_CHECKING:
-    from pyshacl.pytypes import GraphLike, RDFNode
+    from pyshacl.pytypes import RDFNode
     from pyshacl.shapes_graph import ShapesGraph
 
 
@@ -141,7 +141,7 @@ def value_nodes_from_path(sg, focus, path_val, target_graph, recursion=0):
 
 
 def nodes_from_node_expression(
-    expr, focus_node, data_graph: 'GraphLike', sg: 'ShapesGraph', recurse_depth=0
+    expr, focus_node, data_graph: rdflib.Graph, sg: 'ShapesGraph', recurse_depth=0
 ) -> Union[Set[Union['RDFNode', None]], List[Union['RDFNode', None]]]:
     # https://www.w3.org/TR/shacl-af/#node-expressions
     if expr == SH_this:

--- a/pyshacl/pytypes.py
+++ b/pyshacl/pytypes.py
@@ -4,11 +4,9 @@
 from dataclasses import dataclass
 from typing import Optional, Union
 
-from rdflib import ConjunctiveGraph, Dataset, Graph, Literal
+from rdflib import Literal
 from rdflib.term import IdentifiedNode, Node
 
-ConjunctiveLike = Union[ConjunctiveGraph, Dataset]
-GraphLike = Union[ConjunctiveLike, Graph]
 RDFNode = Union[IdentifiedNode, Literal]
 BaseNode = Node
 

--- a/pyshacl/rdfutil/clone.py
+++ b/pyshacl/rdfutil/clone.py
@@ -3,19 +3,19 @@
 from typing import Optional, Union
 
 import rdflib
+from rdflib import ConjunctiveGraph
 from rdflib.collection import Collection
 from rdflib.graph import DATASET_DEFAULT_GRAPH_ID
 from rdflib.namespace import NamespaceManager
 
 from .consts import OWL, RDF_first
-from .pytypes import ConjunctiveLike, GraphLike
 
 OWLsameAs = OWL.sameAs
 
 
-def clone_dataset(source_ds: ConjunctiveLike, target_ds=None):
+def clone_dataset(source_ds: ConjunctiveGraph, target_ds=None):
     if target_ds and not isinstance(target_ds, (rdflib.Dataset, rdflib.ConjunctiveGraph)):
-        raise RuntimeError("when cloning a dataset, the target_ds must be a conjunctiveGraph or rdflib Dataset.")
+        raise RuntimeError("when cloning a dataset, the target_ds must be a ConjunctiveGraph or rdflib Dataset.")
     default_union = source_ds.default_union
     if target_ds is None:
         target_ds = rdflib.Dataset(default_union=default_union)
@@ -100,7 +100,7 @@ def clone_graph(source_graph, target_graph=None, identifier=None):
 
 
 def mix_datasets(
-    base_ds: ConjunctiveLike, extra_ds: GraphLike, target_ds: Optional[Union[ConjunctiveLike, str]] = None
+    base_ds: ConjunctiveGraph, extra_ds: rdflib.Graph, target_ds: Optional[Union[ConjunctiveGraph, str]] = None
 ):
     """
     Make a clone of base_ds (dataset) and add in the triples from extra_ds (dataset)
@@ -205,7 +205,9 @@ def mix_datasets(
     return target_ds
 
 
-def mix_graphs(base_graph: GraphLike, extra_graph: GraphLike, target_graph: Optional[Union[GraphLike, str]] = None):
+def mix_graphs(
+    base_graph: rdflib.Graph, extra_graph: rdflib.Graph, target_graph: Optional[Union[rdflib.Graph, str]] = None
+):
     """
     Make a clone of base_graph and add in the triples from extra_graph
     :param base_graph:

--- a/pyshacl/rdfutil/consts.py
+++ b/pyshacl/rdfutil/consts.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-from typing import Union
-
-from rdflib import RDF, RDFS, ConjunctiveGraph, Dataset, Graph, Namespace
+from rdflib import RDF, RDFS, Namespace
 from rdflib.namespace import OWL
 from rdflib.term import Node
 
@@ -10,8 +8,6 @@ RDFS_Resource = RDFS.Resource
 RDF_first = RDF.first
 SH = Namespace('http://www.w3.org/ns/shacl#')
 
-ConjunctiveLike = Union[ConjunctiveGraph, Dataset]
-GraphLike = Union[ConjunctiveLike, Graph]
 RDFNode = Node
 
 OWL_properties = [

--- a/pyshacl/rdfutil/inoculate.py
+++ b/pyshacl/rdfutil/inoculate.py
@@ -2,11 +2,12 @@ from itertools import chain
 from typing import TYPE_CHECKING, Dict, Optional, Union
 
 import rdflib
+from rdflib import ConjunctiveGraph
 from rdflib.graph import DATASET_DEFAULT_GRAPH_ID
 from rdflib.namespace import NamespaceManager
 
 from .clone import clone_blank_node, clone_graph, clone_node
-from .consts import OWL, RDF, ConjunctiveLike, GraphLike, OWL_classes, OWL_properties, RDFS_classes, RDFS_properties
+from .consts import OWL, RDF, OWL_classes, OWL_properties, RDFS_classes, RDFS_properties
 
 if TYPE_CHECKING:
     from rdflib import BNode
@@ -108,7 +109,7 @@ def inoculate(data_graph: rdflib.Graph, ontology: rdflib.Graph):
 
 
 def inoculate_dataset(
-    base_ds: ConjunctiveLike, ontology_ds: GraphLike, target_ds: Optional[Union[ConjunctiveLike, str]] = None
+    base_ds: ConjunctiveGraph, ontology_ds: rdflib.Graph, target_ds: Optional[Union[ConjunctiveGraph, str]] = None
 ):
     """
     Make a clone of base_ds (dataset) and add RDFS and OWL triples from ontology_ds

--- a/pyshacl/rdfutil/load.py
+++ b/pyshacl/rdfutil/load.py
@@ -17,9 +17,6 @@ from rdflib.namespace import NamespaceManager
 
 from .clone import clone_dataset, clone_graph
 
-ConjunctiveLike = Union[rdflib.ConjunctiveGraph, rdflib.Dataset]
-GraphLike = Union[ConjunctiveLike, rdflib.Graph]
-
 is_windows = platform.system() == "Windows"
 MAX_OWL_IMPORT_DEPTH = 3
 baked_in = {}
@@ -113,8 +110,8 @@ def get_rdf_from_web(url: Union[rdflib.URIRef, str]):
 
 
 def load_from_source(
-    source: Union[GraphLike, BufferedIOBase, TextIOBase, BinaryIO, str, bytes],
-    g: Optional[GraphLike] = None,
+    source: Union[rdflib.Graph, BufferedIOBase, TextIOBase, BinaryIO, str, bytes],
+    g: Optional[rdflib.Graph] = None,
     rdf_format: Optional[str] = None,
     multigraph: bool = False,
     do_owl_imports: Union[bool, int] = False,

--- a/pyshacl/rdfutil/load.py
+++ b/pyshacl/rdfutil/load.py
@@ -8,7 +8,7 @@ import sys
 from io import BufferedIOBase, BytesIO, TextIOBase, UnsupportedOperation
 from logging import WARNING, Logger, getLogger
 from pathlib import Path
-from typing import IO, List, Optional, Union, cast
+from typing import IO, BinaryIO, List, Optional, Union, cast
 from urllib import request
 from urllib.error import HTTPError
 
@@ -113,7 +113,7 @@ def get_rdf_from_web(url: Union[rdflib.URIRef, str]):
 
 
 def load_from_source(
-    source: Union[GraphLike, BufferedIOBase, TextIOBase, str, bytes],
+    source: Union[GraphLike, BufferedIOBase, TextIOBase, BinaryIO, str, bytes],
     g: Optional[GraphLike] = None,
     rdf_format: Optional[str] = None,
     multigraph: bool = False,
@@ -139,7 +139,7 @@ def load_from_source(
     :return:
     """
     source_is_graph = False
-    open_source: Optional[BufferedIOBase] = None
+    open_source: Optional[Union[BufferedIOBase, BinaryIO]] = None
     source_was_open: bool = False
     source_as_file: Optional[BufferedIOBase] = None
     source_as_filename: Optional[str] = None

--- a/pyshacl/rdfutil/pytypes.py
+++ b/pyshacl/rdfutil/pytypes.py
@@ -1,8 +1,0 @@
-# -*- coding: utf-8 -*-
-#
-from typing import Union
-
-from rdflib import ConjunctiveGraph, Dataset, Graph
-
-ConjunctiveLike = Union[ConjunctiveGraph, Dataset]
-GraphLike = Union[ConjunctiveLike, Graph]

--- a/pyshacl/rules/__init__.py
+++ b/pyshacl/rules/__init__.py
@@ -2,9 +2,11 @@
 from collections import defaultdict
 from typing import TYPE_CHECKING, Any, Dict, List, Tuple, Type, Union
 
+import rdflib
+
 from pyshacl.consts import RDF_type, SH_rule, SH_SPARQLRule, SH_TripleRule
 from pyshacl.errors import ReportableRuntimeError, RuleLoadError
-from pyshacl.pytypes import GraphLike, SHACLExecutor
+from pyshacl.pytypes import SHACLExecutor
 from pyshacl.rules.sparql import SPARQLRule
 from pyshacl.rules.triple import TripleRule
 
@@ -77,7 +79,7 @@ def gather_rules(executor: SHACLExecutor, shacl_graph: 'ShapesGraph') -> Dict['S
     return ret_rules
 
 
-def apply_rules(executor: SHACLExecutor, shapes_rules: Dict, data_graph: GraphLike) -> int:
+def apply_rules(executor: SHACLExecutor, shapes_rules: Dict, data_graph: rdflib.Graph) -> int:
     # short the shapes dict by shapes sh:order before execution
     sorted_shapes_rules: List[Tuple[Any, Any]] = sorted(shapes_rules.items(), key=lambda x: x[0].order)
     total_modified = 0

--- a/pyshacl/rules/sparql/__init__.py
+++ b/pyshacl/rules/sparql/__init__.py
@@ -13,7 +13,7 @@ from pyshacl.rdfutil import clone_graph
 from ..shacl_rule import SHACLRule
 
 if TYPE_CHECKING:
-    from pyshacl.pytypes import GraphLike, SHACLExecutor
+    from pyshacl.pytypes import SHACLExecutor
     from pyshacl.shape import Shape
 
 XSD_string = XSD.string
@@ -49,7 +49,7 @@ class SPARQLRule(SHACLRule):
         query_helper.collect_prefixes()
         self._qh = query_helper
 
-    def apply(self, data_graph: 'GraphLike') -> int:
+    def apply(self, data_graph: rdflib.Graph) -> int:
         focus_nodes = self.shape.focus_nodes(data_graph)  # uses target nodes to find focus nodes
         all_added = 0
         SPARQLQueryHelper = get_query_helper_cls()

--- a/pyshacl/rules/triple/__init__.py
+++ b/pyshacl/rules/triple/__init__.py
@@ -12,7 +12,7 @@ from pyshacl.rules.shacl_rule import SHACLRule
 if TYPE_CHECKING:
     from rdflib.term import Node
 
-    from pyshacl.pytypes import GraphLike, SHACLExecutor
+    from pyshacl.pytypes import SHACLExecutor
     from pyshacl.shape import Shape
 
 
@@ -50,7 +50,7 @@ class TripleRule(SHACLRule):
             raise RuntimeError("Too many sh:object")
         self.o = next(iter(my_object_nodes))
 
-    def apply(self, data_graph: 'GraphLike') -> int:
+    def apply(self, data_graph: rdflib.Graph) -> int:
         focus_nodes = self.shape.focus_nodes(data_graph)  # uses target nodes to find focus nodes
         applicable_nodes = self.filter_conditions(focus_nodes, data_graph)
         all_added = 0

--- a/pyshacl/shape.py
+++ b/pyshacl/shape.py
@@ -6,6 +6,7 @@ from decimal import Decimal
 from time import perf_counter
 from typing import TYPE_CHECKING, List, Optional, Set, Tuple, Type, Union
 
+import rdflib
 from rdflib import BNode, Literal, URIRef
 
 from .consts import (
@@ -38,7 +39,7 @@ from .consts import (
 from .errors import ConstraintLoadError, ConstraintLoadWarning, ReportableRuntimeError, ShapeLoadError
 from .helper import get_query_helper_cls
 from .helper.expression_helper import value_nodes_from_path
-from .pytypes import GraphLike, SHACLExecutor
+from .pytypes import SHACLExecutor
 
 if TYPE_CHECKING:
     from pyshacl.constraints import ConstraintComponent
@@ -423,7 +424,7 @@ class Shape(object):
     def validate(
         self,
         executor: SHACLExecutor,
-        target_graph: GraphLike,
+        target_graph: rdflib.Graph,
         focus: Optional[
             Union[
                 Tuple[Union[URIRef, BNode]],

--- a/pyshacl/target.py
+++ b/pyshacl/target.py
@@ -2,12 +2,14 @@ import typing
 from typing import List, Sequence, Type, Union
 from warnings import warn
 
+import rdflib
+
 from .constraints import ConstraintComponent
 from .consts import SH, RDF_type, RDFS_subClassOf, SH_parameter, SH_select, SH_SPARQLTargetType
 from .errors import ConstraintLoadError, ShapeLoadError
 from .helper import get_query_helper_cls
 from .parameter import SHACLParameter
-from .pytypes import GraphLike, SHACLExecutor
+from .pytypes import SHACLExecutor
 
 if typing.TYPE_CHECKING:
     from .shapes_graph import ShapesGraph
@@ -117,7 +119,11 @@ class BoundSHACLTargetType(ConstraintComponent):
         return SH_SPARQLTargetType
 
     def evaluate(
-        self, executor: SHACLExecutor, target_graph: GraphLike, focus_value_nodes: typing.Dict, _evaluation_path: List
+        self,
+        executor: SHACLExecutor,
+        target_graph: rdflib.Graph,
+        focus_value_nodes: typing.Dict,
+        _evaluation_path: List,
     ):
         """
         :type executor: SHACLExecutor


### PR DESCRIPTION
Remove -Likes

While trying to understand some of the code base's typing a bit better, I checked the definition of `GraphLike` and found it was not fulfilling the same role as "-like" parameters I had seen in RDFLib.  This PR removes replaces types specialized to pySHACL with classes used more broadly in RDFLib.  If it turns out there was another purpose these -Likes were serving, I don't mind this PR being NACKed and closed, though I'd be curious to hear about the use case.

This PR builds on [PR 228](https://github.com/RDFLib/pySHACL/pull/228).  The first patch in the PR documents specific rationales on removing `GraphLike` and `ConjunctiveLike`.  Some parameter type revisions around `ConjunctiveGraph` vs. `Dataset` are intentionally left out of the first patch, and I leave it to the maintainers whether they should be added to this PR.