### PR TITLE
Type clone.py node functions

### DIFF
--- a/pyshacl/constraints/core/shape_based_constraints.py
+++ b/pyshacl/constraints/core/shape_based_constraints.py
@@ -2,7 +2,6 @@
 """
 https://www.w3.org/TR/shacl/#core-components-shape
 """
-from dataclasses import dataclass
 from textwrap import indent
 from typing import Dict, List
 from warnings import warn
@@ -77,7 +76,7 @@ class PropertyConstraintComponent(ConstraintComponent):
     ):
         """
         Entrypoint for constraint evaluation.
-        :type executor: dataclass
+        :type executor: SHACLExecutor
         :type target_graph: rdflib.Graph
         :type focus_value_nodes: dict
         :type _evaluation_path: list

--- a/pyshacl/constraints/core/shape_based_constraints.py
+++ b/pyshacl/constraints/core/shape_based_constraints.py
@@ -83,7 +83,6 @@ class PropertyConstraintComponent(ConstraintComponent):
         """
         reports: List[Dict] = []
         non_conformant = False
-        shape = self.shape
 
         # Shortcut, when there are no value nodes, don't check for recursion, don't validate and exit early
         value_node_count = 0
@@ -177,7 +176,6 @@ class NodeConstraintComponent(ConstraintComponent):
         """
         reports: List[Dict] = []
         non_conformant = False
-        shape = self.shape
 
         # Shortcut, when there are no value nodes, don't check for recursion, don't validate and exit early
         value_node_count = 0
@@ -343,7 +341,6 @@ class QualifiedValueShapeConstraintComponent(ConstraintComponent):
         """
         reports: List[Dict] = []
         non_conformant = False
-        shape = self.shape
 
         # Shortcut, when there are no value nodes, don't check for recursion, don't validate and exit early
         value_node_count = 0

--- a/pyshacl/rdfutil/clone.py
+++ b/pyshacl/rdfutil/clone.py
@@ -254,7 +254,9 @@ def clone_list(graph, lnode, target_graph, keepid=False, recursion=0, deep_clone
     return cloned_node
 
 
-def clone_blank_node(graph, bnode, target_graph, keepid=False, recursion=0):
+def clone_blank_node(
+    graph: rdflib.Graph, bnode: rdflib.BNode, target_graph: rdflib.Graph, keepid: bool = False, recursion: int = 0
+) -> rdflib.BNode:
     if not isinstance(graph, rdflib.Graph):
         raise RuntimeError("clone_blank_node must take an rdflib.Graph as first parameter")
     if not isinstance(bnode, rdflib.BNode):

--- a/pyshacl/rdfutil/clone.py
+++ b/pyshacl/rdfutil/clone.py
@@ -311,7 +311,7 @@ def clone_blank_node(
     return cloned_bnode
 
 
-def clone_literal(graph, node, target_graph):
+def clone_literal(graph: rdflib.Graph, node: rdflib.Literal, target_graph: rdflib.Graph) -> rdflib.Literal:
     lex_val_string = str(node)
     lang = node.language
     datatype = node.datatype
@@ -323,6 +323,7 @@ def clone_node(
     graph: rdflib.Graph, node: RDFNode, target_graph: rdflib.Graph, recursion: int = 0, deep_clone: bool = False
 ) -> RDFNode:
     # If deepclone, when the type is URIRef, it clones _all_ node content (properties, objects)
+    new_node: RDFNode
     if isinstance(node, rdflib.Literal):
         new_node = clone_literal(graph, node, target_graph)
     elif isinstance(node, rdflib.BNode):

--- a/pyshacl/rdfutil/clone.py
+++ b/pyshacl/rdfutil/clone.py
@@ -7,7 +7,7 @@ from rdflib.collection import Collection
 from rdflib.graph import DATASET_DEFAULT_GRAPH_ID
 from rdflib.namespace import NamespaceManager
 
-from .consts import OWL, RDF_first
+from .consts import OWL, RDF_first, RDFNode
 from .pytypes import ConjunctiveLike, GraphLike
 
 OWLsameAs = OWL.sameAs
@@ -319,7 +319,9 @@ def clone_literal(graph, node, target_graph):
     return new_literal
 
 
-def clone_node(graph, node, target_graph, recursion=0, deep_clone=False):
+def clone_node(
+    graph: rdflib.Graph, node: RDFNode, target_graph: rdflib.Graph, recursion: int = 0, deep_clone: bool = False
+) -> RDFNode:
     # If deepclone, when the type is URIRef, it clones _all_ node content (properties, objects)
     if isinstance(node, rdflib.Literal):
         new_node = clone_literal(graph, node, target_graph)

--- a/pyshacl/rdfutil/clone.py
+++ b/pyshacl/rdfutil/clone.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-from typing import Optional, Union
+from typing import Optional, Union, overload
 
 import rdflib
 from rdflib.collection import Collection
@@ -235,6 +235,28 @@ def mix_graphs(base_graph: GraphLike, extra_graph: GraphLike, target_graph: Opti
         g = clone_graph(base_graph, target_graph=target_graph)
     g = clone_graph(extra_graph, target_graph=g)
     return g
+
+
+@overload
+def clone_list(
+    graph: rdflib.Graph,
+    lnode: rdflib.BNode,
+    target_graph: rdflib.Graph,
+    keepid: bool = ...,
+    recursion: int = ...,
+    deep_clone: bool = ...,
+) -> rdflib.BNode: ...
+
+
+@overload
+def clone_list(
+    graph: rdflib.Graph,
+    lnode: rdflib.URIRef,
+    target_graph: rdflib.Graph,
+    keepid: bool = ...,
+    recursion: int = ...,
+    deep_clone: bool = ...,
+) -> rdflib.URIRef: ...
 
 
 def clone_list(graph, lnode, target_graph, keepid=False, recursion=0, deep_clone=False):

--- a/pyshacl/rdfutil/load.py
+++ b/pyshacl/rdfutil/load.py
@@ -8,7 +8,7 @@ import sys
 from io import BufferedIOBase, BytesIO, TextIOBase, UnsupportedOperation
 from logging import WARNING, Logger, getLogger
 from pathlib import Path
-from typing import IO, BinaryIO, List, Optional, Union, cast
+from typing import IO, List, Optional, Union, cast
 from urllib import request
 from urllib.error import HTTPError
 
@@ -113,7 +113,7 @@ def get_rdf_from_web(url: Union[rdflib.URIRef, str]):
 
 
 def load_from_source(
-    source: Union[GraphLike, BufferedIOBase, TextIOBase, BinaryIO, str, bytes],
+    source: Union[GraphLike, BufferedIOBase, TextIOBase, str, bytes],
     g: Optional[GraphLike] = None,
     rdf_format: Optional[str] = None,
     multigraph: bool = False,
@@ -139,7 +139,7 @@ def load_from_source(
     :return:
     """
     source_is_graph = False
-    open_source: Optional[Union[BufferedIOBase, BinaryIO]] = None
+    open_source: Optional[BufferedIOBase] = None
     source_was_open: bool = False
     source_as_file: Optional[BufferedIOBase] = None
     source_as_filename: Optional[str] = None
@@ -316,7 +316,7 @@ def load_from_source(
         filename = str(Path(filename).resolve())
         if not public_id:
             public_id = Path(filename).as_uri() + "#"
-        source = open_source = open(filename, mode='rb')
+        source = open_source = cast(BufferedIOBase, open(filename, mode='rb'))
     if not open_source and source_as_bytes:
         source = open_source = BytesIO(source_as_bytes)  # type: ignore
     if open_source:

--- a/pyshacl/rdfutil/load.py
+++ b/pyshacl/rdfutil/load.py
@@ -8,7 +8,7 @@ import sys
 from io import BufferedIOBase, BytesIO, TextIOBase, UnsupportedOperation
 from logging import WARNING, Logger, getLogger
 from pathlib import Path
-from typing import IO, List, Optional, Union, cast
+from typing import IO, BinaryIO, List, Optional, Union, cast
 from urllib import request
 from urllib.error import HTTPError
 
@@ -113,7 +113,7 @@ def get_rdf_from_web(url: Union[rdflib.URIRef, str]):
 
 
 def load_from_source(
-    source: Union[GraphLike, BufferedIOBase, TextIOBase, str, bytes],
+    source: Union[GraphLike, BufferedIOBase, TextIOBase, BinaryIO, str, bytes],
     g: Optional[GraphLike] = None,
     rdf_format: Optional[str] = None,
     multigraph: bool = False,
@@ -139,7 +139,7 @@ def load_from_source(
     :return:
     """
     source_is_graph = False
-    open_source: Optional[BufferedIOBase] = None
+    open_source: Optional[Union[BufferedIOBase, BinaryIO]] = None
     source_was_open: bool = False
     source_as_file: Optional[BufferedIOBase] = None
     source_as_filename: Optional[str] = None


### PR DESCRIPTION
This pull request adds type annotations to functions in `clone.py` not affected by [PR 229](https://github.com/RDFLib/pySHACL/pull/229).

This PR builds on [PR 228](https://github.com/RDFLib/pySHACL/pull/228).