### PR TITLE
Add ConstraintLoadError link

### DIFF
--- a/pyshacl/constraints/constraint_component.py
+++ b/pyshacl/constraints/constraint_component.py
@@ -436,5 +436,6 @@ class CustomConstraintComponent(object):
 
     def make_validator_for_shape(self, shape: 'Shape'):
         raise ConstraintLoadError(
-            "A Custom Constraint must include one of a SPARQLConstraintComponent validator or a JSConstraint validator."
+            "A Custom Constraint must include one of a SPARQLConstraintComponent validator or a JSConstraint validator.",
+            "https://www.w3.org/TR/shacl/#constraint-components-validators",
         )


### PR DESCRIPTION
This patch adds a link that type review noted was missing.

The link added in this PR's first patch is duplicated from prior references in the same file.  The SHACL JavaScript Extensions page seems to offer another possible link, but I was not able to find a note there on the described requirements.

References:
* https://www.w3.org/TR/shacl-js/#js-constraints