### PR TITLE
Give firm type hint on SELECT query result

### DIFF
--- a/pyshacl/constraints/core/other_constraints.py
+++ b/pyshacl/constraints/core/other_constraints.py
@@ -216,6 +216,7 @@ class ClosedConstraintComponent(ConstraintComponent):
             found_fvpo = []
             if len(results) > 0:
                 for r in results:
+                    assert isinstance(r, rdflib.query.ResultRow)
                     for i, f in enumerate(focus_value_nodes.keys()):
                         for j, v in enumerate(focus_value_nodes[f]):
                             p = r[f"p{i}_{j}"]


### PR DESCRIPTION
This patch handles a type review matter not yet automatically provided by `Graph.query`, though rdflib Issue 2283 is planned to provide a mechanism for this.

References:
* https://github.com/RDFLib/rdflib/issues/2283