### PR TITLE
Rename variables to refresh typing

### DIFF
--- a/pyshacl/constraints/core/other_constraints.py
+++ b/pyshacl/constraints/core/other_constraints.py
@@ -243,16 +243,16 @@ class ClosedConstraintComponent(ConstraintComponent):
             for f, value_nodes in focus_value_nodes.items():
                 for v in value_nodes:
                     pred_obs = target_graph.predicate_objects(v)
-                    for p, o in pred_obs:
-                        if (p, o) in self.ALWAYS_IGNORE:
+                    for _p, _o in pred_obs:
+                        if (_p, _o) in self.ALWAYS_IGNORE:
                             continue
-                        elif p in self.ignored_props:
+                        elif _p in self.ignored_props:
                             continue
-                        elif p in working_paths:
+                        elif _p in working_paths:
                             continue
                         non_conformant = True
-                        o_node = cast(RDFNode, o)
-                        p_node = cast(RDFNode, p)
+                        o_node = cast(RDFNode, _o)
+                        p_node = cast(RDFNode, _p)
                         rept = self.make_v_result(target_graph, f, value_node=o_node, result_path=p_node)
                         reports.append(rept)
         return (not non_conformant), reports


### PR DESCRIPTION
Type review has the potential to become confused from reused variable names.  At least one type-checking system sees the variable `o` on line 246 and carries forward a memory from another branch that `o` is typed as an identifier, which is a narrower requirement than the broader `Node` (`RDFNode`) that `target_graph.predicate_objects()` yields.

For type review, this patch renames `o` to `_o`.

For symmetry, the same is done to `_p`, though just doing `_o` was sufficient to resolve the type review issue.