### PR TITLE
Enable type checking in Continuous Integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+# Portions of this file contributed by NIST are governed by the
+# following statement:
+#
+# This software was developed at the National Institute of Standards
+# and Technology by employees of the Federal Government in the course
+# of their official duties. Pursuant to Title 17 Section 105 of the
+# United States Code, this software is not subject to copyright
+# protection within the United States. NIST assumes no responsibility
+# whatsoever for its use by other parties, and makes no guarantees,
+# expressed or implied, about its quality, reliability, or any other
+# characteristic.
+#
+# We would appreciate acknowledgement if the software is used.
+
+name: Continuous Integration
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version:
+          - '3.8'
+          - '3.12'
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Run tests
+      run: |
+          python3 -m venv venv
+          source venv/bin/activate
+          pip install poetry
+          make dev
+          make type-check


### PR DESCRIPTION
This Pull Request adds type checking to a continuous integration (CI) process outside of the two CI systems currently encoded in this repository.  The CI workflow set up uses GitHub Actions, but in a matter naïve to other systems that have some scripting written in this repository.  E.g., I'm not familiar with `tox`.

Feedback or revisions are welcome on this PR.  My objective with the PR is to type-check code on the way in.  I'm aware that there are other tests, but I'm not sure how they're all meant to be called, so the PR starts small: Check types on the oldest and newest Python releases designated in `pyproject.toml`.


## Disclaimer:

Participation by NIST in the creation of the documentation of mentioned software is not intended to imply a recommendation or endorsement by the National Institute of Standards and Technology, nor is it intended to imply that any specific software is necessarily the best available for the purpose.