### PR TITLE
Fix when using targeted shapes, when shape has sh:or, sh:xone or sh:and

### DIFF
--- a/pyshacl/shapes_graph.py
+++ b/pyshacl/shapes_graph.py
@@ -416,7 +416,12 @@ class ShapesGraph(object):
                     for _p in has_shape_expecting_p.keys():
                         property_entries = list(g.objects(s, _p))
                         for p_e in property_entries:
-                            if isinstance(p_e, rdflib.BNode):
+                            if _p in (SH_or, SH_xone, SH_and):
+                                # These are list-expecting variants of shape-expecting constraints.
+                                for item in g.items(p_e):
+                                    if isinstance(item, rdflib.BNode):
+                                        _found_child_bnodes.append(item)
+                            elif isinstance(p_e, rdflib.BNode):
                                 _found_child_bnodes.append(p_e)
                 if len(_found_child_bnodes) > 0:
                     _gather_shapes(_found_child_bnodes, recurse_depth=recurse_depth + 1)

--- a/test/test_manual_targeting.py
+++ b/test/test_manual_targeting.py
@@ -84,10 +84,11 @@ exShape:HumanShape a sh:NodeShape ;
 
 exShape:AnimalShape a sh:NodeShape ;
     sh:property [
-        sh:datatype xsd:integer ;
         sh:path exOnt:nLegs ;
-        sh:maxInclusive 4 ;
-        sh:minInclusive 1 ;
+        sh:or (
+            [ sh:datatype xsd:integer ; sh:minInclusive 0 ; sh:maxInclusive 0 ]
+            [ sh:datatype xsd:integer ; sh:minInclusive 1 ; sh:maxInclusive 8 ]
+        ) ;
     ] ;
     sh:targetClass exOnt:Animal .
 """
@@ -195,6 +196,21 @@ def test_validate_fail_manual_targeting_shape():
     assert "Results (2)" in string
     assert not conforms
 
+def test_validate_fail_manual_targeting_shape_or():
+    res = validate(
+        data_file_text_bad,
+        shacl_graph=shacl_file_text,
+        data_graph_format='turtle',
+        shacl_graph_format='turtle',
+        ont_graph=ontology_file_text,
+        ont_graph_format="turtle",
+        inference='rdfs',
+        use_shapes=["exShape:AnimalShape"],
+        debug=True,
+    )
+    conforms, graph, string = res
+    assert "Results (2)" in string
+    assert not conforms
 
 def test_validate_fail_manual_targeting_focus_with_shape():
     res = validate(


### PR DESCRIPTION
Fix when using targeted shapes, when shape has sh:or, sh:xone or sh:and, now includes all BNodes from their member list.
Fixes #280