### PR TITLE
Look for added triples in the target graph only

### DIFF
--- a/pyshacl/rules/sparql/__init__.py
+++ b/pyshacl/rules/sparql/__init__.py
@@ -60,6 +60,13 @@ class SPARQLRule(SHACLRule):
         focus_nodes: Optional[Sequence['RDFNode']] = None,
         target_graph_identifier: Optional['URIRef'] = None,
     ) -> int:
+        if data_graph.is_multigraph():
+            if target_graph_identifier is not None:
+                target_graph = data_graph.get_context(target_graph_identifier)
+            else:
+                target_graph = data_graph.default_graph
+        else:
+            target_graph = data_graph
         focus_list: Sequence['RDFNode']
         if focus_nodes is not None:
             focus_list = list(focus_nodes)
@@ -101,7 +108,7 @@ class SPARQLRule(SHACLRule):
                     if result_graph is None:
                         raise ReportableRuntimeError("Query executed by a SHACL SPARQLRule did not return a Graph.")
                     for i in result_graph:
-                        if not this_added and i not in data_graph:
+                        if not this_added and i not in target_graph:
                             this_added = True
                             # We only need to know at least one triple was added, then break!
                             break
@@ -109,13 +116,6 @@ class SPARQLRule(SHACLRule):
                         added += 1
                         construct_graphs.add(result_graph)
             if added > 0:
-                if data_graph.is_multigraph():
-                    if target_graph_identifier is not None:
-                        target_graph = data_graph.get_context(target_graph_identifier)
-                    else:
-                        target_graph = data_graph.default_graph
-                else:
-                    target_graph = data_graph
                 for g in construct_graphs:
                     data_graph = clone_graph(g, target_graph=target_graph)
                 all_added += added

--- a/test/test_sparql_rule.py
+++ b/test/test_sparql_rule.py
@@ -1,0 +1,71 @@
+"""\
+A test which checks that SPARQLRule's generate triples in the default graph of a datasets, even if these triples are
+already present in a different graph of that dataset.
+"""
+
+from pyshacl import validate
+from rdflib import Graph, Dataset, RDFS, URIRef, Literal
+
+shacl_file = '''\
+# prefix: ex
+
+@prefix ex: <http://datashapes.org/shasf/tests/expression/sparql-rule.test.shacl#> .
+@prefix exOnt: <http://datashapes.org/shasf/tests/expression/sparql-rule.test.ont#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+
+<http://datashapes.org/shasf/tests/expression/sparql-rule.test.shacl>
+  a owl:Ontology ;
+  rdfs:label "Test of SPARQLRule in conjunction with datasets" ;
+.
+
+ex:rule a sh:SPARQLRule ;
+  sh:construct """
+    CONSTRUCT {
+      $this rdfs:label ?label .
+    }
+    WHERE {
+      $this exOnt:firstName ?firstName .
+      $this exOnt:lastName ?lastName .
+      BIND(CONCAT(?firstName, " ", ?lastName) AS ?label)
+    }
+  """ ;
+.
+
+ex:PersonExpressionShape
+    a sh:NodeShape ;
+    sh:targetClass exOnt:Person ;
+    sh:rule ex:rule ;
+    .
+'''
+
+data_graph = '''
+# prefix: ex
+
+@prefix ex: <http://datashapes.org/shasf/tests/expression/sparql-rule.test.data#> .
+@prefix exOnt: <http://datashapes.org/shasf/tests/expression/sparql-rule.test.ont#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+ex:Kate
+  a exOnt:Person ;
+  rdfs:label "Kate Jones" ;
+  exOnt:firstName "Kate" ;
+  exOnt:lastName "Jones" ;
+.
+'''
+
+def test_sparql_rule():
+    dataset = Dataset()
+    dataset.graph().parse(data=data_graph, format="turtle")
+    s = Graph().parse(data=shacl_file, format="turtle")
+    validate(dataset, shacl_graph=s, advanced=True, debug=False, inplace=True)
+    assert (
+        URIRef("http://datashapes.org/shasf/tests/expression/sparql-rule.test.data#Kate"),
+        RDFS.label,
+        Literal("Kate Jones"),
+    ) in dataset.default_context
+
+
+if __name__ == "__main__":
+    exit(test_sparql_rule())


### PR DESCRIPTION
Hi,

the current SPARQLRule implementation will put all generated triples into the `default_context` when the `validate` function is called with a `Dataset` (and not a single `Graph`). But the check if a generated triple is already present (or has been previously generated) looks at the whole dataset. So, if this triple is present in a different graph of the dataset it will not be put into the default_context.

This currently breaks our application where we need to extract only the generated triples and have to provide additional triples (needed for the validation and generation) via extra graphs. And where we sometimes want triples to be generated even if they are already present in these extra graphs.

This PR includes some adjustments to only check the `target_graph` and adds a test.

Does this look like something you want to include? I'm also happy to do further adjustments. :)

Best regards,
Fabian