### PR TITLE
Enhance shape filtering logic to prevent failures when omitted Shapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Python PEP 440 Versioning](https://www.python.org/d
   - Fixes #301
 - Validation report text output is now deterministic.
   - Fixes #304
+- `use_shapes` filtering no longer fails when omitted PropertyShapes are referenced by included shapes.
+  - Fixes #298
 
 ## [0.30.1] - 2025-03-15
 

--- a/pyshacl/constraints/core/other_constraints.py
+++ b/pyshacl/constraints/core/other_constraints.py
@@ -177,6 +177,8 @@ class ClosedConstraintComponent(ConstraintComponent):
 
         working_shapes = set()
         for p_shape in self.property_shapes:
+            if self.shape.sg.is_filtered_out_shape(p_shape):
+                continue
             property_shape = self.shape.get_other_shape(p_shape)
             if not property_shape or not property_shape.is_property_shape:
                 raise ReportableRuntimeError(

--- a/pyshacl/shape.py
+++ b/pyshacl/shape.py
@@ -130,6 +130,8 @@ class Shape(object):
         self._advanced = bool(val)
 
     def get_other_shape(self, shape_node):
+        if self.sg.is_filtered_out_shape(shape_node):
+            return None
         try:
             return self.sg.lookup_shape_from_node(shape_node)
         except (KeyError, AttributeError):

--- a/test/issues/test_298.py
+++ b/test/issues/test_298.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+#
+"""
+https://github.com/RDFLib/pySHACL/issues/298
+"""
+import sys
+
+from rdflib import Graph
+from rdflib.plugins.parsers.jsonld import to_rdf
+
+import pyshacl
+
+
+def test_298():
+    shapes_graph = to_rdf(
+        {
+            "@context": {
+                "ex": "http://example.org/",
+                "sh": "http://www.w3.org/ns/shacl#",
+            },
+            "@graph": [
+                {
+                    "@id": "ex:PersonShape",
+                    "@type": "sh:NodeShape",
+                    "sh:targetClass": {"@id": "ex:Person"},
+                    "sh:property": [
+                        {
+                            "@id": "ex:NameProperty",
+                            "sh:path": {"@id": "ex:name"},
+                            "sh:minCount": 1,
+                        },
+                        {
+                            "@id": "ex:AgeProperty",
+                            "sh:path": {"@id": "ex:age"},
+                            "sh:minInclusive": 18,
+                        },
+                    ],
+                }
+            ],
+        },
+        Graph(),
+    )
+
+    data_graph = to_rdf(
+        {
+            "@context": {
+                "ex": "http://example.org/",
+            },
+            "@id": "ex:person1",
+            "@type": "ex:Person",
+            "ex:name": "John Doe",
+            "ex:age": 25,
+        },
+        Graph(),
+    )
+
+    conforms, report_graph, results_text = pyshacl.validate(
+        data_graph,
+        shacl_graph=shapes_graph,
+        use_shapes=[
+            "http://example.org/PersonShape",
+            "http://example.org/NameProperty",
+        ],
+    )
+    assert conforms
+    assert "Validation Report" in results_text
+
+
+if __name__ == "__main__":
+    sys.exit(test_298())

--- a/test/issues/test_301.py
+++ b/test/issues/test_301.py
@@ -59,5 +59,4 @@ def test_301():
 
 
 if __name__ == "__main__":
-    test_301()
     sys.exit(test_301())

--- a/test/issues/test_304.py
+++ b/test/issues/test_304.py
@@ -112,3 +112,6 @@ def test_304():
     assert "Results (" in out_a
     assert out_a == out_b
     assert out_a == out_c
+
+if __name__ == "__main__":
+    sys.exit(test_304())


### PR DESCRIPTION
Enhance shape filtering logic to prevent failures when omitted PropertyShapes are referenced. Update validation components to skip filtered shapes. Add test for issue #298 to ensure correct behavior.