### PR TITLE
fix(rdflib): adapt pySHACL to Dataset API deprecations in RDFLib 7.3+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ classifiers = [
     "Operating System :: OS Independent"
 ]
 dependencies = [
-    "rdflib[html]>=7.1.1,<8.0,!=7.1.2",
+    "rdflib[html]>=7.3.0,<8.0",
     "owlrl>=7.1.2,<8",
     "prettytable>=3.5.0; python_version<'3.12'",
     "prettytable>=3.7.0; python_version>='3.12'",

--- a/pyshacl/entrypoints.py
+++ b/pyshacl/entrypoints.py
@@ -14,7 +14,7 @@ from pyshacl.pytypes import GraphLike
 
 from .consts import SH, RDF_type
 from .monkey import apply_patches, rdflib_bool_patch, rdflib_bool_unpatch
-from .rdfutil import load_from_source
+from .rdfutil import get_default_graph, load_from_source
 from .rule_expand_runner import RuleExpandRunner
 from .validator import Validator, assign_baked_in
 from .validator_conformance import check_dash_result
@@ -31,7 +31,7 @@ def _is_multi_data_graph_input(data_graph: object) -> bool:
 
 def _multi_data_graph_key(source: DataGraphInput) -> Union[str, URIRef]:
     if isinstance(source, (Graph, Dataset, ConjunctiveGraph)):
-        return source.identifier
+        return get_default_graph(source).identifier
     if isinstance(source, (BufferedIOBase, TextIOBase)):
         return getattr(source, "name", repr(source))
     if isinstance(source, bytes):

--- a/pyshacl/extras/js/rules.py
+++ b/pyshacl/extras/js/rules.py
@@ -6,6 +6,7 @@ import rdflib
 
 from pyshacl.consts import SH
 from pyshacl.errors import ReportableRuntimeError
+from pyshacl.rdfutil import get_default_graph
 from pyshacl.rules.shacl_rule import SHACLRule
 
 from .js_executable import JSExecutable
@@ -79,7 +80,7 @@ class JSRule(SHACLRule):
                     if target_graph_identifier is not None:
                         target_graph = data_graph.get_context(target_graph_identifier)
                     else:
-                        target_graph = data_graph.default_context
+                        target_graph = get_default_graph(data_graph)
                 else:
                     target_graph = data_graph
                 for s in sets_to_add:

--- a/pyshacl/rdfutil/__init__.py
+++ b/pyshacl/rdfutil/__init__.py
@@ -4,6 +4,7 @@
 
 from .clone import clone_blank_node, clone_graph, clone_literal, clone_node, mix_datasets, mix_graphs  # noqa: F401
 from .compare import compare_blank_node, compare_literal, compare_node, order_graph_literal  # noqa: F401
+from .graph import get_default_graph, set_default_graph  # noqa: F401
 from .inoculate import inoculate, inoculate_dataset  # noqa: F401
 from .load import add_baked_in, get_rdf_from_web, load_from_source  # noqa: F401
 from .stringify import stringify_blank_node, stringify_graph, stringify_literal, stringify_node  # noqa: F401

--- a/pyshacl/rdfutil/clone.py
+++ b/pyshacl/rdfutil/clone.py
@@ -8,6 +8,7 @@ from rdflib.graph import DATASET_DEFAULT_GRAPH_ID
 from rdflib.namespace import NamespaceManager
 
 from .consts import OWL, RDF_first, RDFNode
+from .graph import get_default_graph, set_default_graph
 from .pytypes import ConjunctiveLike, GraphLike
 
 OWLsameAs = OWL.sameAs
@@ -20,7 +21,7 @@ def clone_dataset(source_ds: ConjunctiveLike, target_ds=None):
     if target_ds is None:
         target_ds = rdflib.Dataset(default_union=default_union)
         target_ds.namespace_manager = NamespaceManager(target_ds, 'core')
-        target_ds.default_context.namespace_manager = target_ds.namespace_manager
+        get_default_graph(target_ds).namespace_manager = target_ds.namespace_manager
     named_graphs = [
         (
             rdflib.Graph(source_ds.store, i, namespace_manager=source_ds.namespace_manager)  # type: ignore[arg-type]
@@ -38,17 +39,17 @@ def clone_dataset(source_ds: ConjunctiveLike, target_ds=None):
         for ng in named_graphs
     ]
     source_graph_identifiers = [ng.identifier for ng in named_graphs]
-    source_default_context_id = source_ds.default_context.identifier
-    target_default_context_id = target_ds.default_context.identifier
+    source_default_context_id = get_default_graph(source_ds).identifier
+    target_default_context_id = get_default_graph(target_ds).identifier
     if source_default_context_id != target_default_context_id:
-        old_target_default_context = target_ds.default_context
+        old_target_default_context = get_default_graph(target_ds)
         old_target_default_context_id = old_target_default_context.identifier
         if isinstance(target_ds, rdflib.Dataset):
             new_target_default_context = target_ds.graph(source_default_context_id)
         else:
             new_target_default_context = target_ds.get_context(source_default_context_id)
             target_ds.store.add_graph(new_target_default_context)
-        target_ds.default_context = new_target_default_context
+        set_default_graph(target_ds, new_target_default_context)
         if old_target_default_context_id not in source_graph_identifiers:
             if isinstance(target_ds, rdflib.Dataset):
                 target_ds.remove_graph(old_target_default_context)
@@ -62,8 +63,9 @@ def clone_dataset(source_ds: ConjunctiveLike, target_ds=None):
             t_default = target_ds.get_context(target_default_context_id)
             target_ds.store.add_graph(t_default)
 
+    target_default_graph = get_default_graph(target_ds)
     for g in cloned_graphs:
-        if g == target_ds.default_context or g.identifier == target_default_context_id:
+        if g == target_default_graph or g.identifier == target_default_context_id:
             continue
         if isinstance(target_ds, rdflib.Dataset):
             _ = target_ds.graph(g)  # alias to Dataset.add_graph()
@@ -133,7 +135,7 @@ def mix_datasets(
     if target_ds is None:
         target_ds = rdflib.Dataset(default_union=default_union)
         target_ds.namespace_manager = NamespaceManager(target_ds, 'core')
-        target_ds.default_context.namespace_manager = target_ds.namespace_manager
+        get_default_graph(target_ds).namespace_manager = target_ds.namespace_manager
     elif target_ds == "inplace" or target_ds == "base":
         target_ds = base_ds
     elif isinstance(target_ds, str):
@@ -176,17 +178,17 @@ def mix_datasets(
             mixed_graphs.update(mod_named_graphs)
 
         base_graph_identifiers = [bg.identifier for bg in base_named_graphs]
-        base_default_context_id = base_ds.default_context.identifier
-        target_default_context_id = target_ds.default_context.identifier
+        base_default_context_id = get_default_graph(base_ds).identifier
+        target_default_context_id = get_default_graph(target_ds).identifier
         if base_default_context_id != target_default_context_id:
-            old_target_default_context = target_ds.default_context
+            old_target_default_context = get_default_graph(target_ds)
             old_target_default_context_id = old_target_default_context.identifier
             if isinstance(target_ds, rdflib.Dataset):
                 new_target_default_context = target_ds.graph(base_default_context_id)
             else:
                 new_target_default_context = target_ds.get_context(base_default_context_id)
                 target_ds.store.add_graph(new_target_default_context)
-            target_ds.default_context = new_target_default_context
+            set_default_graph(target_ds, new_target_default_context)
             if old_target_default_context_id not in base_graph_identifiers:
                 if isinstance(target_ds, rdflib.Dataset):
                     target_ds.remove_graph(old_target_default_context)
@@ -199,8 +201,9 @@ def mix_datasets(
             else:
                 t_default = target_ds.get_context(target_default_context_id)
                 target_ds.store.add_graph(t_default)
+        target_default_graph = get_default_graph(target_ds)
         for i, m in mixed_graphs.items():
-            if m == target_ds.default_context or i == target_default_context_id:
+            if m == target_default_graph or i == target_default_context_id:
                 continue
             if isinstance(target_ds, rdflib.Dataset):
                 _ = target_ds.graph(m)  # alias to Dataset.add_graph()

--- a/pyshacl/rdfutil/graph.py
+++ b/pyshacl/rdfutil/graph.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+#
+import rdflib
+
+from .pytypes import ConjunctiveLike, GraphLike
+
+
+def get_default_graph(graph: GraphLike) -> rdflib.Graph:
+    if isinstance(graph, rdflib.Dataset):
+        return graph.default_graph
+    if isinstance(graph, rdflib.ConjunctiveGraph):
+        return graph.default_context
+    return graph
+
+
+def set_default_graph(graph: ConjunctiveLike, default_graph: rdflib.Graph) -> None:
+    if isinstance(graph, rdflib.Dataset):
+        graph.default_graph = default_graph
+    else:
+        graph.default_context = default_graph

--- a/pyshacl/rdfutil/inoculate.py
+++ b/pyshacl/rdfutil/inoculate.py
@@ -5,6 +5,7 @@ import rdflib
 
 from .clone import clone_blank_node, clone_dataset, clone_node
 from .consts import OWL, RDF, ConjunctiveLike, GraphLike, OWL_classes, OWL_properties, RDFS_classes, RDFS_properties
+from .graph import get_default_graph
 
 if TYPE_CHECKING:
     from rdflib import BNode
@@ -146,7 +147,7 @@ def inoculate_dataset(
     if target_graph_identifier:
         dest_graph = target_ds.get_context(target_graph_identifier)
     else:
-        dest_graph = target_ds.default_context
+        dest_graph = get_default_graph(target_ds)
 
     # inoculate() routine will set default_union on the ontology_ds if it is a Dataset
     inoculate(dest_graph, ontology_ds)

--- a/pyshacl/rdfutil/load.py
+++ b/pyshacl/rdfutil/load.py
@@ -18,6 +18,7 @@ from rdflib.namespace import SDO, NamespaceManager
 from rdflib.term import URIRef
 
 from .clone import clone_dataset, clone_graph
+from .graph import get_default_graph, set_default_graph
 
 SCHEMA = SDO
 
@@ -346,15 +347,15 @@ def load_from_source(
                 target_ds = rdflib.Dataset(default_graph_base=default_graph_base, default_union=True)
                 target_ds.namespace_manager = NamespaceManager(target_ds, 'core')
                 if identifier:  # if identifier is explicitly given, use that as a new named graph id
-                    old_default_context = target_ds.default_context
+                    old_default_context = get_default_graph(target_ds)
                     if str(old_default_context.identifier) != identifier:
                         named_g = target_ds.graph(URIRef(identifier))
                         named_g.base = default_graph_base
-                        target_ds.default_context = named_g
+                        set_default_graph(target_ds, named_g)
                         target_ds.remove_graph(old_default_context)
                 else:
-                    target_ds.default_context.namespace_manager = target_ds.namespace_manager
-                    default_g = target_ds.default_context
+                    get_default_graph(target_ds).namespace_manager = target_ds.namespace_manager
+                    default_g = get_default_graph(target_ds)
                     target_ds.graph(default_g)
                 target_g = target_ds
             else:
@@ -494,7 +495,7 @@ def load_from_source(
                 dest_g = target_g.get_context(URIRef(identifier))
                 dest_g.base = parser_base_uri
             else:
-                dest_g = target_g.default_context
+                dest_g = get_default_graph(target_g)
                 dest_g.base = parser_base_uri
             # parsing uses base_uri as the public_id, because it is used for relative URIs
             dest_g.parse(source=cast(IO[bytes], _source), format=rdf_format, publicID=parser_base_uri)
@@ -512,7 +513,7 @@ def load_from_source(
                 # The parser closed our file!
                 pass
         source_is_graph = True
-    elif source_is_graph and (target_g != source):
+    elif source_is_graph and (target_g is not source):
         # clone source into g
         if isinstance(target_g, (rdflib.Dataset, rdflib.ConjunctiveGraph)) and isinstance(
             source, (rdflib.Dataset, rdflib.ConjunctiveGraph)
@@ -567,7 +568,7 @@ def load_from_source(
             if identifier:
                 dest_g = target_g.get_context(URIRef(identifier))
             else:
-                dest_g = target_g.default_context
+                dest_g = get_default_graph(target_g)
         else:
             dest_g = target_g
         return chain_load_owl_imports(

--- a/pyshacl/rule_expand_runner.py
+++ b/pyshacl/rule_expand_runner.py
@@ -15,6 +15,7 @@ from .functions import apply_functions, gather_functions, unapply_functions
 from .pytypes import GraphLike, SHACLExecutor
 from .rdfutil import (
     clone_graph,
+    get_default_graph,
     inoculate,
     inoculate_dataset,
     mix_datasets,
@@ -224,7 +225,8 @@ class RuleExpandRunner(PySHACLRunType):
             on_focus_nodes = None
 
         if self.debug:
-            self.logger.debug(f"Running SHACL Rules on DataGraph named {g.identifier}")
+            graph_id = get_default_graph(g).identifier
+            self.logger.debug(f"Running SHACL Rules on DataGraph named {graph_id}")
         if gathered_functions:
             apply_functions(executor, gathered_functions, g)
         try:

--- a/pyshacl/rules/sparql/__init__.py
+++ b/pyshacl/rules/sparql/__init__.py
@@ -8,7 +8,7 @@ from rdflib.namespace import XSD
 from pyshacl.consts import SH_construct
 from pyshacl.errors import ReportableRuntimeError, RuleLoadError
 from pyshacl.helper import get_query_helper_cls
-from pyshacl.rdfutil import clone_graph
+from pyshacl.rdfutil import clone_graph, get_default_graph
 
 from ..shacl_rule import SHACLRule
 
@@ -112,7 +112,7 @@ class SPARQLRule(SHACLRule):
                     if target_graph_identifier is not None:
                         target_graph = data_graph.get_context(target_graph_identifier)
                     else:
-                        target_graph = data_graph.default_context
+                        target_graph = get_default_graph(data_graph)
                 else:
                     target_graph = data_graph
                 for g in construct_graphs:

--- a/pyshacl/rules/triple/__init__.py
+++ b/pyshacl/rules/triple/__init__.py
@@ -7,6 +7,7 @@ import rdflib
 from pyshacl.consts import SH_object, SH_predicate, SH_subject
 from pyshacl.errors import ReportableRuntimeError
 from pyshacl.helper.expression_helper import nodes_from_node_expression
+from pyshacl.rdfutil import get_default_graph
 from pyshacl.rules.shacl_rule import SHACLRule
 
 if TYPE_CHECKING:
@@ -101,7 +102,7 @@ class TripleRule(SHACLRule):
                     if target_graph_identifier is not None:
                         target_graph = data_graph.get_context(target_graph_identifier)
                     else:
-                        target_graph = data_graph.default_context
+                        target_graph = get_default_graph(data_graph)
                 else:
                     target_graph = data_graph
                 for i in to_add:

--- a/pyshacl/run_type.py
+++ b/pyshacl/run_type.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Optional
 import rdflib
 
 from pyshacl.errors import ReportableRuntimeError
+from pyshacl.rdfutil import get_default_graph
 
 if TYPE_CHECKING:
     from rdflib.term import URIRef
@@ -65,7 +66,7 @@ class PySHACLRunType(metaclass=ABCMeta):
             if destination_graph_identifier is not None:
                 destination_graph = target_graph.get_context(destination_graph_identifier)
             else:
-                destination_graph = target_graph.default_context
+                destination_graph = get_default_graph(target_graph)
         else:
             destination_graph = None
         try:

--- a/pyshacl/shapes_graph.py
+++ b/pyshacl/shapes_graph.py
@@ -28,6 +28,7 @@ from .consts import (
     SH_targetSubjectsOf,
 )
 from .errors import ShapeLoadError
+from .rdfutil import get_default_graph
 from .shape import Shape
 
 if TYPE_CHECKING:
@@ -72,10 +73,7 @@ class ShapesGraph(object):
         return bool(self._use_js)
 
     def _add_system_triples(self):
-        if isinstance(self.graph, (rdflib.Dataset, rdflib.ConjunctiveGraph)):
-            g = self.graph.default_context
-        else:
-            g = self.graph
+        g = get_default_graph(self.graph)
         for t in self.system_triples:
             g.add(t)
 

--- a/pyshacl/validator.py
+++ b/pyshacl/validator.py
@@ -23,6 +23,7 @@ from .rdfutil import (
     add_baked_in,
     clone_blank_node,
     clone_graph,
+    get_default_graph,
     inoculate,
     inoculate_dataset,
     mix_datasets,
@@ -113,7 +114,7 @@ class Validator(PySHACLRunType):
         vr = BNode()
         vg.add((vr, RDF_type, SH_ValidationReport))
         vg.add((vr, SH_conforms, Literal(conforms)))
-        cloned_nodes: Dict[Tuple[GraphLike, str], Union[BNode, URIRef]] = {}
+        cloned_nodes: Dict[Tuple[int, str], Union[BNode, URIRef]] = {}
         text_results = sorted(results, key=lambda r: r[0])
         for result in iter(text_results):
             _d, _bn, _tr = result
@@ -130,12 +131,13 @@ class Validator(PySHACLRunType):
                         o = node  # No need to clone a literal from the data graph
                     else:
                         _id = str(node)
-                        if (source, _id) in cloned_nodes:
-                            o = cloned_nodes[(source, _id)]
+                        source_key = (id(source), _id)
+                        if source_key in cloned_nodes:
+                            o = cloned_nodes[source_key]
                         elif isinstance(node, BNode):
-                            cloned_nodes[(source, _id)] = o = clone_blank_node(source, node, vg, keepid=True)
+                            cloned_nodes[source_key] = o = clone_blank_node(source, node, vg, keepid=True)
                         else:
-                            cloned_nodes[(source, _id)] = o = URIRef(_id)
+                            cloned_nodes[source_key] = o = URIRef(_id)
                 vg.add((s, p, o))
         return vg, v_text
 
@@ -302,9 +304,10 @@ class Validator(PySHACLRunType):
             self._target_graph.default_union = True
 
         g = self._target_graph
+        graph_id = get_default_graph(g).identifier
 
         if self.debug:
-            self.logger.debug(f"Validating DataGraph named {g.identifier}")
+            self.logger.debug(f"Validating DataGraph named {graph_id}")
         if advanced:
             if advanced['functions']:
                 apply_functions(executor, advanced['functions'], g)

--- a/pyshacl/validator_conformance.py
+++ b/pyshacl/validator_conformance.py
@@ -437,7 +437,9 @@ def check_dash_result(
         data_graph = validator.target_graph
         assert data_graph is not None
         if isinstance(data_graph, (rdflib.ConjunctiveGraph, rdflib.Dataset)):
-            named_graphs = list(data_graph.contexts())
+            named_graphs = (
+                list(data_graph.graphs()) if isinstance(data_graph, rdflib.Dataset) else list(data_graph.contexts())
+            )
             was_union: Union[bool, None] = data_graph.default_union
             data_graph.default_union = True
         else:

--- a/test/issues/test_316.py
+++ b/test/issues/test_316.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+"""
+https://github.com/RDFLib/pySHACL/issues/316
+"""
+
+import warnings
+
+import rdflib
+
+from pyshacl import validate
+
+SHAPES_TTL = """\
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:ThingShape a sh:NodeShape ;
+    sh:targetClass ex:Thing ;
+    sh:property [
+        sh:path ex:prop ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+    ] .
+"""
+
+DATA_TTL = """\
+@prefix ex: <http://example.com/> .
+
+ex:node1 a ex:Thing .
+"""
+
+
+def test_316_dataset_validation_avoids_rdflib_deprecations() -> None:
+    data_graph = rdflib.Dataset()
+    data_graph.default_graph.parse(data=DATA_TTL, format="turtle")
+
+    shapes_graph = rdflib.Dataset()
+    shapes_graph.default_graph.parse(data=SHAPES_TTL, format="turtle")
+
+    with warnings.catch_warnings(record=True) as warning_context:
+        warnings.simplefilter("always")
+        conforms, _report_graph, _report_text = validate(data_graph, shacl_graph=shapes_graph)
+
+    assert conforms is False
+    pyshacl_deprecations = [
+        (str(w.message), w.filename)
+        for w in warning_context
+        if issubclass(w.category, DeprecationWarning)
+        and (
+            "Dataset.default_context is deprecated" in str(w.message)
+            or "Dataset.identifier is deprecated" in str(w.message)
+        )
+        and "/pyshacl/" in w.filename.lower()
+        and "/site-packages/" not in w.filename.lower()
+    ]
+    assert pyshacl_deprecations == []

--- a/test/test_schema_org.py
+++ b/test/test_schema_org.py
@@ -38,7 +38,7 @@ def schema_org():
     # print(dataGraph.serialize(format='ttl').decode('utf8'))
 
     shaclDS = rdflib.Dataset()
-    shaclGraph = shaclDS.default_context
+    shaclGraph = shaclDS.default_graph
     shaclDS.graph(shaclGraph)
     shaclGraph.parse(data=shacl, format='ttl')
 


### PR DESCRIPTION
# Summary

Replace deprecated Dataset access patterns with the current RDFLib API: use Dataset.default_graph, Dataset.graphs(), and avoid deprecated Dataset.identifier-dependent paths in pySHACL-owned code.

# Change Log

- Mostly this goes by the recommendations of the deprecation warnings shown by `rdflib`.
- https://github.com/RDFLib/pySHACL/pull/317/changes#diff-bbaee17ef5b3256f96e4eab81bced454e1fa19e082b959d3b777c370b2486df6 is pull-out of duplicated code, which I only wanted to extend once.
- https://github.com/RDFLib/pySHACL/pull/317/changes#diff-e8ebfafbf0f5d7c27a060d34421a3c9f19577a56d12323fef6807712732bf9a3 needed an replacement for the deprecated `Dataset.Identifier`, which before simply created a new object and now I use the https://docs.python.org/3/library/functions.html#id, which is probably OK for all use-cases.
- https://github.com/RDFLib/pySHACL/pull/317/changes#diff-e8ebfafbf0f5d7c27a060d34421a3c9f19577a56d12323fef6807712732bf9a3 now uses the `identifier` of the default graph, which is hopefully also OK.
- A regression test is included for dataset-based validation behavior.
  There are some remaining deprecation warnings from `rdflib` itself, which are ignored in the test.

# Comments

> [!WARNING]
> Please let me know if you have any feedback.
> I am not really an expert on your codebase or the one of `rdflib` in general, but merely use them every now and then and just faced these deprecation warnings.

> [!IMPORTANT]
> BTW, `make test` shows some `type-check` check errors, but these I also have without my changes.
> I am curious to see the workflow results.

> [!CAUTION]
> I have tried to fix https://github.com/RDFLib/pySHACL/pull/317#discussion_r3065619879, but this leads to much more changes in `poetry.lock`, than relevant for this PR. Please advice how to fix that.

---

Closes #316 