### PR TITLE
Big updates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,9 +6,7 @@ build-backend = "poetry.core.masonry.api"
 name = "pyshacl"
 # Don't forget to change the version number in __init__.py, Dockerfile, and CITATION.cff along with this one
 version = "0.31.0"
-# Ruff and Poetry both now read target-version from [project.requires-python]
-# The <4 is reauired for compatiblity with OWL-RL that requdires Python <4
-requires-python = ">=3.9,<4"
+requires-python = ">=3.9"
 description = "Python SHACL Validator"
 license = { file = "LICENSE.txt" }
 authors = [
@@ -46,8 +44,8 @@ classifiers = [
     "Operating System :: OS Independent"
 ]
 dependencies = [
-    "rdflib[html]>=7.1.1,<8.0,!=7.1.2",
-    "owlrl>=7.1.2,<8",
+    "rdflib[html]>=7.3.0,<8.0",
+    "owlrl>=7.6.2,<8",
     "prettytable>=3.5.0; python_version<'3.12'",
     "prettytable>=3.7.0; python_version>='3.12'",
     "packaging>=21.3",
@@ -64,7 +62,11 @@ changelog = "https://github.com/RDFLib/pySHACL/blob/master/CHANGELOG.md"
 [project.optional-dependencies]
 # These are equivelent to python package "extras"
 js = [
-    "pyduktape2<1,>=0.4.6"
+    "pyduktape2<1,>=0.4.6; python_version<='3.13'",
+    "pyduktape2<1,>=0.5.0; python_version>='3.13'",
+]
+oxigraph = [
+    "pyoxigraph>=0.5.6"
 ]
 http = [
     "sanic<23,>=22.12",
@@ -191,7 +193,7 @@ testpaths = [
 legacy_tox_ini = """
 [tox]
 skipsdist = true
-envlist = py39, py310, py311, py312, lint, type-checking
+envlist = py39, py310, py311, py312, py313, lint, type-checking
 toxworkdir={env:TOX_WORK_DIR:.tox}
 
 [testenv]
@@ -241,6 +243,7 @@ commands =
 [gh]
 # Don't include lint or type-checking in gh-actions matrix
 python =
+    3.13 = py313
     3.12 = py312
     3.11 = py311
     3.10 = py310

--- a/pyshacl/cli.py
+++ b/pyshacl/cli.py
@@ -322,6 +322,8 @@ def main(prog: Union[str, None] = None) -> None:
         validator_kwargs['allow_infos'] = True
     if args.allow_warnings:
         validator_kwargs['allow_warnings'] = True
+    if args.max_depth is not None:
+        validator_kwargs['max_validation_depth'] = args.max_depth
     if args.shacl_file_format:
         _f: str = args.shacl_file_format
         if _f != "auto":

--- a/pyshacl/constraints/constraint_component.py
+++ b/pyshacl/constraints/constraint_component.py
@@ -141,7 +141,7 @@ class ConstraintComponent(object, metaclass=abc.ABCMeta):
     ):
         """
         :param datagraph:
-        :type datagraph: rdflib.Graph | rdflib.ConjunctiveGraph | rdflib.Dataset
+        :type datagraph: rdflib.Graph | rdflib.Dataset
         :param focus_node:
         :type focus_node: RDFNode
         :param severity:
@@ -231,7 +231,7 @@ class ConstraintComponent(object, metaclass=abc.ABCMeta):
     ):
         """
         :param datagraph:
-        :type datagraph: rdflib.Graph | rdflib.ConjunctiveGraph | rdflib.Dataset
+        :type datagraph: rdflib.Graph | rdflib.Dataset
         :param focus_node:
         :type focus_node: RDFNode
         :param value_node:

--- a/pyshacl/entrypoints.py
+++ b/pyshacl/entrypoints.py
@@ -7,39 +7,27 @@ from io import BufferedIOBase, TextIOBase
 from sys import stderr
 from typing import Dict, List, Optional, Tuple, Union
 
-from rdflib import ConjunctiveGraph, Dataset, Graph, Literal, URIRef
+from rdflib import Dataset, Graph, Literal, URIRef
 
 from pyshacl.errors import ReportableRuntimeError, ValidationFailure
 from pyshacl.pytypes import GraphLike
 
 from .consts import SH, RDF_type
+from .graph_abstraction import DataGraph, has_oxigraph, ox_Store
 from .monkey import apply_patches, rdflib_bool_patch, rdflib_bool_unpatch
 from .rdfutil import load_from_source
 from .rule_expand_runner import RuleExpandRunner
 from .validator import Validator, assign_baked_in
 from .validator_conformance import check_dash_result
 
-DataGraphInput = Union[GraphLike, BufferedIOBase, TextIOBase, str, bytes]
+DataGraphInput = Union[DataGraph, GraphLike, BufferedIOBase, TextIOBase, str, bytes]
 MultiDataGraphInput = Sequence[DataGraphInput]
 
 
 def _is_multi_data_graph_input(data_graph: object) -> bool:
-    if isinstance(data_graph, (str, bytes, BufferedIOBase, TextIOBase, Graph, Dataset, ConjunctiveGraph)):
+    if isinstance(data_graph, (str, bytes, DataGraph, BufferedIOBase, TextIOBase, Graph, Dataset)):
         return False
     return isinstance(data_graph, (tuple, list, set, frozenset, Sequence))
-
-
-def _multi_data_graph_key(source: DataGraphInput) -> Union[str, URIRef]:
-    if isinstance(source, (Graph, Dataset, ConjunctiveGraph)):
-        return source.identifier
-    if isinstance(source, (BufferedIOBase, TextIOBase)):
-        return getattr(source, "name", repr(source))
-    if isinstance(source, bytes):
-        try:
-            return source.decode("utf-8")
-        except UnicodeDecodeError:
-            return repr(source)
-    return str(source)
 
 
 def validate(
@@ -127,12 +115,12 @@ def validate(
                 sparql_mode=sparql_mode,
                 focus_nodes=focus_nodes,
                 use_shapes=use_shapes,
-                multi_data_graphs_mode=resolved_mode,
                 **kwargs,
             )
         if len(data_graphs) == 1:
             data_graph = data_graphs[0]
         else:
+            # Combined mode, load all the sources into a single dataset
             data_graph_format = kwargs.get('data_graph_format', None)
             combined_dataset = Dataset(default_union=True)
             for source in data_graphs:
@@ -145,7 +133,7 @@ def validate(
                     logger=log,
                 )
             data_graph = combined_dataset
-    do_check_dash_result = kwargs.pop('check_dash_result', False)  # type: bool
+    do_check_dash_result: bool = kwargs.pop('check_dash_result', False)
     if kwargs.get('meta_shacl', False):
         to_meta_val = shacl_graph or data_graph
         conforms, v_r, v_t = meta_validate(to_meta_val, inference=inference, **kwargs)
@@ -173,8 +161,6 @@ def validate(
             raise ReportableRuntimeError("Cannot use SPARQL Remote Graph Mode with extra Ontology Graph inoculation.")
         if isinstance(data_graph, bytes):
             data_graph = data_graph.decode('utf-8')
-        else:
-            data_graph = data_graph
         ephemeral = False
         inplace = True
     if (
@@ -195,11 +181,19 @@ def validate(
             auth = None
         store = SPARQLStore(query_endpoint=query_endpoint, auth=auth, method=method)
         loaded_dg = Dataset(store=store, default_union=True)
+        dg = DataGraph.from_rdflib_dataset(loaded_dg)
+    elif isinstance(data_graph, DataGraph):
+        loaded_dg = data_graph.impl
+        dg = data_graph
+    elif has_oxigraph and isinstance(data_graph, ox_Store):
+        loaded_dg = data_graph
+        dg = DataGraph.from_oxigraph_store(loaded_dg)
     else:
         # force no owl imports on data_graph
         loaded_dg = load_from_source(
             data_graph, rdf_format=data_graph_format, multigraph=True, do_owl_imports=False, logger=log
         )
+        dg = DataGraph.from_rdflib(loaded_dg)
     ont_graph_format = kwargs.pop('ont_graph_format', None)
     if ont_graph is not None:
         loaded_og = load_from_source(
@@ -241,7 +235,7 @@ def validate(
     validator = None
     try:
         validator = Validator(
-            loaded_dg,
+            dg,
             shacl_graph=loaded_sg,
             ont_graph=loaded_og,
             options=validator_options_dict,
@@ -252,7 +246,7 @@ def validate(
         report_graph = e
         report_text = "Validation Failure - {}".format(e.message)
     if do_check_dash_result and validator is not None:
-        passes = check_dash_result(validator, report_graph, loaded_sg or loaded_dg)
+        passes = check_dash_result(validator, report_graph, loaded_sg or dg)
         return passes, report_graph, report_text
     do_serialize_report_graph = kwargs.pop('serialize_report_graph', False)
     if do_serialize_report_graph and isinstance(report_graph, Graph):
@@ -277,15 +271,14 @@ def validate_each(
     sparql_mode: Optional[bool] = False,
     focus_nodes: Optional[List[Union[str, URIRef]]] = None,
     use_shapes: Optional[List[Union[str, URIRef]]] = None,
-    multi_data_graphs_mode: Optional[str] = None,
     **kwargs,
-) -> Dict[Union[str, URIRef], Tuple[bool, Union[GraphLike, bytes, ValidationFailure], str]]:
+) -> Dict[int, Tuple[bool, Union[GraphLike, bytes, ValidationFailure], str]]:
     """
     :param data_graphs: Sequence of data graphs or sources to validate independently
     :type data_graphs: Sequence
     :param multi_data_graphs_mode: Optional mode hint for compatibility with validate()
     :type multi_data_graphs_mode: str | None
-    :return: dict mapping each input graph identifier to its validation results
+    :return: dict mapping each input graph index to its validation results
     """
 
     if not _is_multi_data_graph_input(data_graphs):
@@ -293,8 +286,8 @@ def validate_each(
     data_graph_list = list(data_graphs)
     if len(data_graph_list) < 1:
         raise ReportableRuntimeError("No data graphs were provided for validate_each.")
-    results: Dict[Union[str, URIRef], Tuple[bool, Union[GraphLike, bytes, ValidationFailure], str]] = {}
-    for data_graph in data_graph_list:
+    results: Dict[int, Tuple[bool, Union[GraphLike, bytes, ValidationFailure], str]] = {}
+    for datagraph_i, data_graph in enumerate(data_graph_list):
         result = validate(
             data_graph,
             *args,
@@ -310,10 +303,9 @@ def validate_each(
             sparql_mode=sparql_mode,
             focus_nodes=focus_nodes,
             use_shapes=use_shapes,
-            multi_data_graphs_mode=multi_data_graphs_mode,
             **kwargs,
         )
-        results[_multi_data_graph_key(data_graph)] = result
+        results[datagraph_i] = result
     return results
 
 
@@ -416,10 +408,18 @@ def shacl_rules(
     else:
         ephemeral = False
     use_js = kwargs.pop('js', None)
-    # force no owl imports on data_graph
-    loaded_dg = load_from_source(
-        data_graph, rdf_format=data_graph_format, multigraph=True, do_owl_imports=False, logger=log
-    )
+    if isinstance(data_graph, DataGraph):
+        loaded_dg = data_graph.impl
+        dg = data_graph
+    elif has_oxigraph and isinstance(data_graph, ox_Store):
+        loaded_dg = data_graph
+        dg = DataGraph.from_oxigraph_store(loaded_dg)
+    else:
+        # force no owl imports on data_graph
+        loaded_dg = load_from_source(
+            data_graph, rdf_format=data_graph_format, multigraph=True, do_owl_imports=False, logger=log
+        )
+        dg = DataGraph.from_rdflib(loaded_dg)
     ont_graph_format = kwargs.pop('ont_graph_format', None)
     if ont_graph is not None:
         loaded_og = load_from_source(
@@ -450,7 +450,7 @@ def shacl_rules(
     serialize_expanded_graph = kwargs.get('serialize_expanded_graph', None)
     try:
         runner = RuleExpandRunner(
-            loaded_dg,
+            dg,
             shacl_graph=loaded_sg,
             ont_graph=loaded_og,
             options=runner_options_dict,
@@ -466,7 +466,7 @@ def shacl_rules(
             g.add((URIRef("<urn:rdflib:pyshacl:shacl-rules-error>"), SH.message, Literal(error)))
             return g
     if serialize_expanded_graph:
-        guess_format = "trig" if isinstance(expanded_graph, (Dataset, ConjunctiveGraph)) else "turtle"
+        guess_format = "trig" if isinstance(expanded_graph, Dataset) else "turtle"
         serialize_format = kwargs.get('serialize_expanded_graph_format', guess_format)
         return expanded_graph.serialize(format=serialize_format)
     return expanded_graph

--- a/pyshacl/extras/js/function.py
+++ b/pyshacl/extras/js/function.py
@@ -1,17 +1,29 @@
 #
 #
-import typing
+from __future__ import annotations
 
-from rdflib.plugins.sparql.operators import register_custom_function, unregister_custom_function
+import functools
+import typing
+from typing import Dict, Union
+
 from rdflib.plugins.sparql.sparql import SPARQLError
 
-from pyshacl.errors import ReportableRuntimeError
-from pyshacl.functions.shacl_function import SHACLFunction
-
+from ...errors import ReportableRuntimeError
+from ...functions.shacl_function import SHACLFunction
+from ...graph_abstraction import has_oxigraph, to_ox, to_rdf
 from .js_executable import JSExecutable
 
 if typing.TYPE_CHECKING:
-    from pyshacl.shapes_graph import ShapesGraph
+    from ...graph_abstraction import DataGraph
+    from ...shapes_graph import ShapesGraph
+if has_oxigraph:
+    from pyoxigraph import BlankNode as ox_BlankNode
+    from pyoxigraph import NamedNode as ox_NamedNode
+    from pyoxigraph import Triple as ox_Triple
+else:
+    ox_BlankNode = None
+    ox_NamedNode = None
+    ox_Triple = None
 
 
 class JSFunction(SHACLFunction):
@@ -56,10 +68,59 @@ class JSFunction(SHACLFunction):
         res = results['_result']
         return res
 
-    def apply(self, g):
-        super(JSFunction, self).apply(g)
-        register_custom_function(self.node, self.execute_from_sparql, True, True)
+    def execute_oxigraph(
+        self,
+        g: 'DataGraph',
+        args_map: Dict[str, Union[ox_NamedNode, ox_BlankNode, ox_Triple]],
+    ):
+        """Run the SHACL-JS function body and return a pyoxigraph term."""
+        rdf_args_map = {k: to_rdf(v) if v is not None else None for k, v in args_map.items()}
+        results = self.js_exe.execute(g, rdf_args_map, mode="function", return_type=self.rtype)
+        res = results['_result']
+        if res is None:
+            return None
+        return to_ox(res)
 
-    def unapply(self, g):
+    def execute_from_sparql_oxigraph(
+        self,
+        g: 'DataGraph',
+        *args: Union[ox_NamedNode, ox_BlankNode, ox_Triple],
+    ):
+        """Oxigraph custom-function callback: evaluated argument terms in, one RDF term out."""
+        if not g.is_oxigraph:
+            raise ReportableRuntimeError("execute_from_sparql_oxigraph requires an Oxigraph-backed DataGraph.")
+        params = self.get_params_in_order()
+        num_params = len(params)
+        num_args = len(args)
+        if num_args > num_params:
+            raise ValueError("Too many parameters passed to JSFunction {}.".format(self.node))
+        if num_args < num_params:
+            raise ValueError("Too few parameters passed to JSFunction {}.".format(self.node))
+        args_map: Dict[str, Union[ox_NamedNode, ox_BlankNode, ox_Triple]] = {}
+        for i, p in enumerate(params):
+            ox_arg = args[i]
+            ln = p.localname
+            if ox_arg is None and p.optional is False:
+                raise ReportableRuntimeError("Got NoneType for Non-optional argument {}.".format(ln))
+            args_map[ln] = ox_arg
+        return self.execute_oxigraph(g, args_map)
+
+    def apply(self, g: 'DataGraph'):
+        super(JSFunction, self).apply(g)
+        if has_oxigraph:
+            g.register_custom_function(
+                self.node,
+                self.execute_from_sparql,
+                functools.partial(self.execute_from_sparql_oxigraph, g),
+                True,
+                True,
+            )
+        else:
+            g.register_custom_function(self.node, self.execute_from_sparql, None, True, True)
+
+    def unapply(self, g: 'DataGraph'):
         super(JSFunction, self).unapply(g)
-        unregister_custom_function(self.node, self.execute_from_sparql)
+        if has_oxigraph:
+            g.unregister_custom_function(self.node, self.execute_from_sparql, self.execute_from_sparql_oxigraph)
+        else:
+            g.unregister_custom_function(self.node, self.execute_from_sparql, None)

--- a/pyshacl/extras/js/rules.py
+++ b/pyshacl/extras/js/rules.py
@@ -75,11 +75,11 @@ class JSRule(SHACLRule):
                 if this_added:
                     added += 1
             if added > 0:
-                if isinstance(data_graph, (rdflib.Dataset, rdflib.ConjunctiveGraph)):
+                if isinstance(data_graph, rdflib.Dataset):
                     if target_graph_identifier is not None:
                         target_graph = data_graph.get_context(target_graph_identifier)
                     else:
-                        target_graph = data_graph.default_context
+                        target_graph = data_graph.default_graph
                 else:
                     target_graph = data_graph
                 for s in sets_to_add:

--- a/pyshacl/functions/__init__.py
+++ b/pyshacl/functions/__init__.py
@@ -3,7 +3,7 @@
 import sys
 from typing import TYPE_CHECKING, Dict, Sequence, Union
 
-from pyshacl.consts import (
+from ..consts import (
     RDF_type,
     SH_ask,
     SH_JSFunction,
@@ -13,12 +13,12 @@ from pyshacl.consts import (
     SH_SHACLFunction,
     SH_SPARQLFunction,
 )
-from pyshacl.pytypes import GraphLike, RDFNode, SHACLExecutor
+from ..pytypes import RDFNode, SHACLExecutor
 
 if TYPE_CHECKING:
-    from pyshacl.extras.js.function import JSFunction  # noqa F401
-    from pyshacl.shapes_graph import ShapesGraph
-
+    from ..extras.js.function import JSFunction  # noqa F401
+    from ..shapes_graph import ShapesGraph
+    from ..graph_abstraction import DataGraph
     from .shacl_function import SHACLFunction, SPARQLFunction
 
 
@@ -99,11 +99,11 @@ def gather_functions(
     return list(all_fns.values())
 
 
-def apply_functions(executor: SHACLExecutor, fns: Sequence, data_graph: GraphLike):
+def apply_functions(executor: SHACLExecutor, fns: Sequence, data_graph: 'DataGraph'):
     for f in fns:
         f.apply(data_graph)
 
 
-def unapply_functions(fns: Sequence, data_graph: GraphLike):
+def unapply_functions(fns: Sequence, data_graph: 'DataGraph'):
     for f in fns:
         f.unapply(data_graph)

--- a/pyshacl/functions/shacl_function.py
+++ b/pyshacl/functions/shacl_function.py
@@ -1,24 +1,175 @@
 # -*- coding: utf-8 -*-
 #
+from __future__ import annotations
+
+import functools
+import re
 import typing
-from typing import Dict, List
+from typing import Dict, List, Sequence
 
 from rdflib import XSD, Literal
-from rdflib.plugins.sparql.operators import register_custom_function, unregister_custom_function
 from rdflib.plugins.sparql.sparql import SPARQLError
 
 from ..consts import SH, RDFS_comment, SH_ask, SH_parameter, SH_select
 from ..errors import ConstraintLoadError, ReportableRuntimeError
+from ..graph_abstraction import has_oxigraph, to_ox, to_rdf
 from ..helper import get_query_helper_cls
 from ..parameter import SHACLParameter
 
 if typing.TYPE_CHECKING:
+    from pyoxigraph import (
+        BlankNode,
+        NamedNode,
+        Triple,
+    )
+    from pyoxigraph import (
+        Literal as OxLiteral,
+    )
+
+    from ..graph_abstraction import DataGraph, OxigraphDataGraph
     from ..pytypes import GraphLike
     from ..shapes_graph import ShapesGraph
+
+if has_oxigraph:
+    from pyoxigraph import Literal as ox_Literal
+    from pyoxigraph import QueryBoolean as ox_QueryBoolean
+    from pyoxigraph import QuerySolutions as ox_QuerySolutions
 
 
 SH_returnType = SH.returnType
 SH_optional = SH.optional
+
+_SPARQL_VAR_TOKEN = re.compile(r"(\?|\$)([a-zA-Z_][\w]*)")
+
+
+def _skip_sparql_string(query: str, start: int) -> int:
+    """Advance past a SPARQL string literal opener at *start*."""
+    quote = query[start]
+    i = start + 1
+    n = len(query)
+    while i < n:
+        if query[i] == "\\":
+            i += 2
+            continue
+        if query[i] == quote:
+            return i + 1
+        i += 1
+    return n
+
+
+def _find_keyword_at_brace_depth_zero(query: str, keyword: str, start: int = 0) -> int | None:
+    """Return the index of *keyword* only when it appears at SPARQL graph-pattern depth zero."""
+    keyword_re = re.compile(rf"(?i)\b{re.escape(keyword)}\b")
+    i = start
+    n = len(query)
+    brace_depth = 0
+    while i < n:
+        ch = query[i]
+        if ch in ('"', "'"):
+            i = _skip_sparql_string(query, i)
+            continue
+        if ch == "{":
+            brace_depth += 1
+            i += 1
+            continue
+        if ch == "}":
+            brace_depth = max(0, brace_depth - 1)
+            i += 1
+            continue
+        if brace_depth == 0:
+            m = keyword_re.match(query, i)
+            if m:
+                return i
+        i += 1
+    return None
+
+
+def _split_top_level_select_query(query: str) -> tuple[str, str, str] | None:
+    """Split *query* into (prefix, select_clause, suffix).
+
+    *prefix* is any prologue and text before the top-level ``SELECT``.
+    *select_clause* is the projection between top-level ``SELECT`` and ``WHERE``.
+    *suffix* begins with the top-level ``WHERE`` keyword, or is empty when absent.
+
+    Only the outermost ``SELECT`` is considered; nested ``SELECT`` inside ``WHERE``
+    graph patterns are left untouched.
+    """
+    select_kw = _find_keyword_at_brace_depth_zero(query, "SELECT", 0)
+    if select_kw is None:
+        return None
+    select_match = re.match(r"(?i)\bSELECT\b", query[select_kw:])
+    if select_match is None:
+        return None
+    select_clause_start = select_kw + select_match.end()
+    where_kw = _find_keyword_at_brace_depth_zero(query, "WHERE", select_clause_start)
+    if where_kw is not None:
+        select_clause = query[select_clause_start:where_kw].strip()
+        suffix = query[where_kw:]
+    else:
+        select_clause = query[select_clause_start:].strip()
+        suffix = ""
+    prefix = query[:select_kw]
+    return prefix, select_clause, suffix
+
+
+def _collect_bare_projected_var_names(select_clause: str) -> set[str]:
+    """Return variable names projected at the top level of a SELECT clause.
+
+    Variables that only appear inside parenthesized ``(expr AS ?var)`` expressions
+    are not counted, because Oxigraph does not treat them as explicit projections
+    for substitution purposes.
+    """
+    projected: set[str] = set()
+    depth = 0
+    i = 0
+    n = len(select_clause)
+    while i < n:
+        ch = select_clause[i]
+        if ch in ('"', "'"):
+            i = _skip_sparql_string(select_clause, i)
+            continue
+        if ch == "(":
+            depth += 1
+            i += 1
+            continue
+        if ch == ")":
+            depth = max(0, depth - 1)
+            i += 1
+            continue
+        if depth == 0:
+            m = _SPARQL_VAR_TOKEN.match(select_clause, i)
+            if m:
+                projected.add(m.group(2))
+                i = m.end()
+                continue
+        i += 1
+    return projected
+
+
+def _preferred_var_sigil(select_clause: str, name: str) -> str:
+    """Pick ``$`` or ``?`` for a variable name, matching existing query style when possible."""
+    if re.search(rf"\${re.escape(name)}\b", select_clause):
+        return "$"
+    if re.search(rf"\?{re.escape(name)}\b", select_clause):
+        return "?"
+    return "$"
+
+
+def _append_top_level_select_projections(query: str, binding_names: Sequence[str]) -> str:
+    """Append any missing top-level SELECT projections required by Oxigraph substitutions."""
+    parts = _split_top_level_select_query(query)
+    if parts is None:
+        return query
+    prefix, select_clause, suffix = parts
+    bare_projected = _collect_bare_projected_var_names(select_clause)
+    missing = [name for name in binding_names if name not in bare_projected]
+    if not missing:
+        return query
+    extra = " ".join(f"{_preferred_var_sigil(select_clause, name)}{name}" for name in missing)
+    new_select_clause = f"{select_clause} {extra}".strip()
+    if suffix:
+        return f"{prefix}SELECT {new_select_clause} {suffix}"
+    return f"{prefix}SELECT {new_select_clause}"
 
 
 class SHACLFunction(object):
@@ -140,10 +291,19 @@ class SPARQLFunction(SHACLFunction):
             if arg is None and p.optional is False:
                 raise ReportableRuntimeError("Got NoneType for Non-optional argument {}.".format(ln))
             init_bindings[ln] = arg
+        if getattr(g, "is_oxigraph", False):
+            ox_bindings = {k: to_ox(v) for k, v in init_bindings.items()}
+            if self.ask:
+                return Literal(bool(self.execute_ask_oxigraph(g, ox_bindings)))
+            ox_result = self.execute_select_oxigraph(g, ox_bindings)
+            return to_rdf(ox_result) if ox_result is not None else None
         if self.ask:
             return self.execute_ask(g, init_bindings)
-        else:
-            return self.execute_select(g, init_bindings)
+        return self.execute_select(g, init_bindings)
+
+    def _ensure_oxigraph_select_bindings(self, select: str, binding_names: Sequence[str]) -> str:
+        """Oxigraph requires substituted variables to appear as bare SELECT projections."""
+        return _append_top_level_select_projections(select.strip(), binding_names)
 
     def execute_select(self, g: 'GraphLike', init_bindings: Dict):
         s = self._qh.apply_prefixes(self.select)
@@ -164,6 +324,35 @@ class SPARQLFunction(SHACLFunction):
         if results.type != "ASK":
             raise ReportableRuntimeError("Was expecting an ASK response from the Ask query.")
         return Literal(results.askAnswer)
+
+    def execute_select_oxigraph(
+        self,
+        g: 'OxigraphDataGraph',
+        init_bindings: Dict[str, NamedNode | BlankNode | OxLiteral | Triple],
+    ):
+        s = self._qh.apply_prefixes(self.select)
+        s = self._ensure_oxigraph_select_bindings(s, list(init_bindings.keys()))
+        results = g.query_oxigraph(s, initBindings=init_bindings)
+        if not isinstance(results, ox_QuerySolutions):
+            raise ReportableRuntimeError("Was expecting a SELECT response from the Select query.")
+        if len(results.variables) < 1:
+            return None
+        try:
+            solution = next(iter(results))
+        except StopIteration:
+            return None
+        return solution[0]
+
+    def execute_ask_oxigraph(
+        self,
+        g: 'OxigraphDataGraph',
+        init_bindings: Dict[str, NamedNode | BlankNode | OxLiteral | Triple],
+    ):
+        a = self._qh.apply_prefixes(self.ask)
+        results = g.query_oxigraph(a, initBindings=init_bindings)
+        if not isinstance(results, ox_QueryBoolean):
+            raise ReportableRuntimeError("Was expecting an ASK response from the Ask query.")
+        return ox_Literal(bool(results))
 
     def execute_from_sparql(self, e, ctx):
         if not e.expr:
@@ -186,10 +375,53 @@ class SPARQLFunction(SHACLFunction):
         else:
             return self.execute_select(g, new_binds)
 
-    def apply(self, g):
-        super(SPARQLFunction, self).apply(g)
-        register_custom_function(self.node, self.execute_from_sparql, True, True)
+    def execute_from_sparql_oxigraph(
+        self,
+        g: 'DataGraph',
+        *args: NamedNode | BlankNode | OxLiteral | Triple,
+    ):
+        """Oxigraph custom-function callback: evaluated argument terms in, one RDF term out.
 
-    def unapply(self, g):
+        PyOxigraph invokes this with one positional argument per SPARQL function argument
+        (pyoxigraph NamedNode, BlankNode, Literal, or Triple). The DataGraph is not provided
+        by Oxigraph; apply() binds it with functools.partial().
+        """
+        if not g.is_oxigraph:
+            raise ReportableRuntimeError("execute_from_sparql_oxigraph requires an Oxigraph-backed DataGraph.")
+        params = self.get_params_in_order()
+        num_params = len(params)
+        num_args = len(args)
+        if num_args > num_params:
+            raise ValueError("Too many parameters passed to SPARQLFunction {}.".format(self.node))
+        if num_args < num_params:
+            raise ValueError("Too few parameters passed to SPARQLFunction {}.".format(self.node))
+        init_bindings: Dict[str, NamedNode | BlankNode | OxLiteral | Triple] = {}
+        for i, p in enumerate(params):
+            ox_arg = args[i]
+            ln = p.localname
+            if ox_arg is None and p.optional is False:
+                raise ReportableRuntimeError("Got NoneType for Non-optional argument {}.".format(ln))
+            init_bindings[ln] = ox_arg
+        if self.ask:
+            return self.execute_ask_oxigraph(g, init_bindings)
+        return self.execute_select_oxigraph(g, init_bindings)
+
+    def apply(self, g: 'DataGraph'):
+        super(SPARQLFunction, self).apply(g)
+        if has_oxigraph:
+            g.register_custom_function(
+                self.node,
+                self.execute_from_sparql,
+                functools.partial(self.execute_from_sparql_oxigraph, g),
+                True,
+                True,
+            )
+        else:
+            g.register_custom_function(self.node, self.execute_from_sparql, None, True, True)
+
+    def unapply(self, g: 'DataGraph'):
         super(SPARQLFunction, self).unapply(g)
-        unregister_custom_function(self.node, self.execute_from_sparql)
+        if has_oxigraph:
+            g.unregister_custom_function(self.node, self.execute_from_sparql, self.execute_from_sparql_oxigraph)
+        else:
+            g.unregister_custom_function(self.node, self.execute_from_sparql, None)

--- a/pyshacl/graph_abstraction.py
+++ b/pyshacl/graph_abstraction.py
@@ -1,0 +1,1421 @@
+try:
+    from pyoxigraph import (
+        BlankNode as ox_BlankNode,
+    )
+    from pyoxigraph import (
+        DefaultGraph as ox_DefaultGraph,
+    )
+    from pyoxigraph import (
+        Literal as ox_Literal,
+    )
+    from pyoxigraph import (
+        NamedNode as ox_NamedNode,
+    )
+    from pyoxigraph import (
+        Quad as ox_Quad,
+    )
+    from pyoxigraph import (
+        QueryBoolean as ox_QueryBoolean,
+    )
+    from pyoxigraph import (
+        QuerySolutions as ox_QuerySolutions,
+    )
+    from pyoxigraph import (
+        QueryTriples as ox_QueryTriples,
+    )
+    from pyoxigraph import (
+        Store as ox_Store,
+    )
+    from pyoxigraph import (
+        Triple as ox_Triple,
+    )
+    from pyoxigraph import (
+        Variable as ox_Variable,
+    )
+
+    has_oxigraph = True
+except ImportError:
+    has_oxigraph = False
+    ox_Store = None
+    ox_DefaultGraph = None
+    ox_Quad = None
+    ox_Literal = None
+    ox_BlankNode = None
+    ox_NamedNode = None
+    ox_QuerySolutions = None
+    ox_Variable = None
+
+import shutil
+import warnings
+from pathlib import Path
+from typing import Any, Callable, Dict, Generator, Iterable, Mapping, Sequence, Tuple, Type, Union
+
+from rdflib import Dataset as rdf_Dataset
+from rdflib import Graph as rdf_Graph
+from rdflib import IdentifiedNode
+from rdflib.graph import DATASET_DEFAULT_GRAPH_ID
+from rdflib.namespace import RDF, NamespaceManager
+from rdflib.plugins.sparql.operators import register_custom_function, unregister_custom_function
+from rdflib.plugins.sparql.sparql import Query, Update
+from rdflib.query import Processor, Result
+from rdflib.store import VALID_STORE
+from rdflib.store import Store as rdflib_Store
+from rdflib.term import (
+    BNode as rdf_BNode,
+)
+from rdflib.term import (
+    IdentifiedNode as rdf_IdentifiedNode,
+)
+from rdflib.term import (
+    Literal as rdf_Literal,
+)
+from rdflib.term import (
+    URIRef as rdf_URIRef,
+)
+from rdflib.term import (
+    Variable as rdf_Variable,
+)
+
+ALLOWED_BACKING_TYPES = Union[rdflib_Store, ox_Store]
+
+
+class DataGraph(rdf_Dataset):
+    is_oxigraph: bool
+    impl: ALLOWED_BACKING_TYPES
+    _default_union: bool
+
+    def __new__(
+        cls,
+        store: ALLOWED_BACKING_TYPES,
+        impl: Union[rdf_Dataset, rdf_Graph, None] = None,
+        locked_context: Union[rdf_Graph, str, None] = None,
+    ):
+        use_oxigraph = has_oxigraph and isinstance(store, ox_Store)
+        if cls is DataGraph:
+            # Determine the correct subclass to use
+            if use_oxigraph:
+                cls = OxigraphDataGraph
+            else:
+                cls = RdfLibDataGraph
+            self = cls.__new__(cls, store, locked_context)
+            return self
+        else:
+            self = super().__new__(cls)
+            self.is_oxigraph = use_oxigraph
+            self._default_union = False
+            return self
+
+    @classmethod
+    def is_multigraph(self) -> bool:
+        return False
+
+    @property
+    def default_union(self) -> bool:
+        return self._default_union
+
+    @property
+    def default_graph(self):
+        raise NotImplementedError("Default graph is not supported for this graph type")
+
+    @default_union.setter
+    def default_union(self, value: bool):
+        self._default_union = value
+        if self.is_oxigraph:
+            pass
+        else:
+            impl = getattr(self, 'impl', None)
+            if impl and isinstance(impl, rdf_Dataset):
+                impl.default_union = value
+
+    @property
+    def namespace_manager(self) -> NamespaceManager:
+        raise NotImplementedError("Namespace manager is not supported for this graph type")
+
+    def query(self, **kwargs):
+        raise NotImplementedError("Query is not supported for this graph type")
+
+    @classmethod
+    def from_rdflib_dataset(cls, dataset: rdf_Dataset) -> "DataGraph":
+        return cls(store=dataset.store, impl=dataset)
+
+    @classmethod
+    def from_rdflib_graph(cls, graph: rdf_Graph) -> "DataGraph":
+        return cls(store=graph.store, impl=graph)
+
+    @classmethod
+    def from_rdflib(cls, source: Union[rdf_Dataset, rdf_Graph]) -> "DataGraph":
+        if isinstance(source, rdf_Dataset):
+            return cls.from_rdflib_dataset(source)
+        elif isinstance(source, rdf_Graph):
+            return cls.from_rdflib_graph(source)
+        else:
+            raise ValueError("Invalid rdflib source type")
+
+    @classmethod
+    def from_oxigraph_store(cls, store: ox_Store) -> "DataGraph":
+        if not has_oxigraph:
+            raise ValueError("pyoxigraph is not installed")
+        return cls(store, impl=None)
+
+    def register_custom_function(
+        self,
+        function_name: str | rdf_IdentifiedNode,
+        rdflib_fn: Callable,
+        oxigraph_fn: Callable,
+        override: bool = False,
+        raw: bool = False,
+        is_aggregate: bool = False,
+    ):
+        raise NotImplementedError("register_custom_function is not supported for this graph type")
+
+    def clone(self) -> "DataGraph":
+        raise NotImplementedError("clone is not supported for this graph type")
+
+    @property
+    def identifier(self) -> str:
+        return self.impl.identifier
+
+
+class RdfLibDataGraph(DataGraph):
+    locked_context: rdf_Graph | None
+    is_multi_graph: bool
+    _store: rdflib_Store
+    impl: Union[rdf_Dataset, rdf_Graph]
+
+    def __init__(
+        self,
+        store: rdflib_Store,
+        impl: Union[rdf_Dataset, rdf_Graph, None] = None,
+        locked_context: Union[rdf_Graph, str, None] = None,
+    ):
+        if impl is not None:
+            if isinstance(impl, rdf_Dataset):
+                _default_union = impl.default_union
+                _is_multi_graph = True
+            else:
+                _default_union = False
+                _is_multi_graph = False
+            self.impl = impl
+            self._store = store
+            rdf_Dataset.__init__(self, default_union=_default_union)
+            self.is_multi_graph = _is_multi_graph
+        else:
+            self._store = store
+            self.impl = super(RdfLibDataGraph, self)
+            rdf_Dataset.__init__(self, store=store, default_union=False)
+            self.is_multi_graph = True
+        if isinstance(locked_context, rdf_Graph):
+            self.locked_context = locked_context
+        elif isinstance(locked_context, str):
+            if not self.is_multi_graph:
+                self.locked_context = self.impl
+            else:
+                self.locked_context = self.impl.get_context(rdf_URIRef(locked_context))
+        else:
+            self.locked_context = None
+
+    def clone(
+        self, destination: Union[rdf_Dataset, rdf_Graph, None] = None, identifier: Union[str, None] = None
+    ) -> "RdfLibDataGraph":
+        if identifier is None:
+            if self.is_multi_graph:
+                identifier = self.default_graph.identifier
+            else:
+                identifier = self.impl.identifier
+        # Lazy import to avoid circular import, where it can depend on graph_abstraction.py.
+        from .rdfutil.clone import clone_graph
+
+        new_impl = clone_graph(self.impl, destination, identifier)
+        return RdfLibDataGraph(new_impl.store, new_impl, self.locked_context)
+
+    @property
+    def default_graph(self) -> rdf_Graph:
+        if self.is_multi_graph:
+            return self.impl.default_graph
+        else:
+            return self.impl
+
+    @property
+    def identifier(self) -> str:
+        if isinstance(self.impl, rdf_Dataset):
+            if self.locked_context:
+                if isinstance(self.locked_context, rdf_Graph):
+                    return self.locked_context.identifier
+                else:
+                    return str(self.locked_context)
+            else:
+                return "RDFLibDataset"
+        elif isinstance(self.impl, rdf_Graph):
+            return str(self.impl.identifier)
+        else:
+            return "RDFLibGraph"
+
+    @property
+    def namespace_manager(self) -> NamespaceManager:
+        return self.impl.namespace_manager
+
+    def is_multigraph(self) -> bool:
+        return self.is_multi_graph
+
+    @property
+    def store(self) -> rdflib_Store:
+        return self._store
+
+    def register_custom_function(
+        self,
+        function_name: rdf_IdentifiedNode,
+        rdflib_fn: Callable,
+        oxigraph_fn: Union[Callable, None] = None,
+        override: bool = False,
+        raw: bool = False,
+        is_aggregate: bool = False,
+    ):
+        register_custom_function(function_name, rdflib_fn, override, raw)
+
+    def unregister_custom_function(
+        self, function_name: rdf_IdentifiedNode, rdflib_fn: Callable, oxigraph_fn: Union[Callable, None] = None
+    ):
+        unregister_custom_function(function_name, rdflib_fn)
+
+    def query(
+        self,
+        query_object: Union[str, Query],
+        processor: Union[str, Processor] = "sparql",
+        result: Union[str, Type[Result]] = "sparql",
+        initNs: Union[Mapping[str, Any], None] = None,  # noqa: N803
+        initBindings: Union[Mapping[str, IdentifiedNode], None] = None,  # noqa: N803
+        use_store_provided: bool = True,
+        **kwargs: Any,
+    ) -> Result:
+        return self.impl.query(query_object, processor, result, initNs, initBindings, use_store_provided, **kwargs)
+
+    def add(
+        self,
+        triple: Tuple[
+            Union[rdf_IdentifiedNode, rdf_Literal],
+            rdf_IdentifiedNode,
+            Union[rdf_Literal, rdf_IdentifiedNode],
+        ],
+    ):
+        if self.locked_context is not None:
+            if isinstance(self.impl, rdf_Dataset):
+                return self.impl.add((triple[0], triple[1], triple[2], self.locked_context))
+            else:
+                return self.locked_context.add((triple[0], triple[1], triple[2]))
+        else:
+            return self.impl.add((triple[0], triple[1], triple[2]))
+
+    def remove(
+        self,
+        triple: Tuple[
+            Union[rdf_IdentifiedNode, rdf_Literal],
+            rdf_IdentifiedNode,
+            Union[rdf_Literal, rdf_IdentifiedNode],
+        ],
+    ):
+        if self.locked_context is not None:
+            if isinstance(self.impl, rdf_Dataset):
+                return self.impl.remove((triple[0], triple[1], triple[2], self.locked_context))
+            else:
+                return self.locked_context.remove((triple[0], triple[1], triple[2]))
+        else:
+            return self.impl.remove((triple[0], triple[1], triple[2]))
+
+    def triples(
+        self,
+        triple: Tuple[
+            Union[rdf_IdentifiedNode, rdf_Literal, None],
+            Union[rdf_IdentifiedNode, None],
+            Union[rdf_IdentifiedNode, rdf_Literal, None],
+        ],
+    ) -> Generator[
+        Tuple[
+            Union[rdf_IdentifiedNode, rdf_Literal],
+            rdf_IdentifiedNode,
+            Union[rdf_IdentifiedNode, rdf_Literal],
+        ],
+        None,
+        None,
+    ]:
+        if self.locked_context is not None:
+            if isinstance(self.impl, rdf_Dataset):
+                yield from self.impl.triples(triple, context=self.locked_context)
+            else:
+                yield from self.locked_context.triples(triple)
+        else:
+            yield from self.impl.triples(triple)
+
+    def subject_objects(
+        self, predicate: Union[rdf_IdentifiedNode, None], unique: bool = False
+    ) -> Generator[tuple, None, None]:
+        if self.locked_context is not None:
+            yield from self.locked_context.subject_objects(predicate, unique=unique)
+        else:
+            yield from self.impl.subject_objects(predicate, unique=unique)
+
+    def subject_predicates(
+        self, object_: Union[rdf_IdentifiedNode, rdf_Literal, None], unique: bool = False
+    ) -> Generator[Any, None, None]:
+        if self.locked_context is not None:
+            yield from self.locked_context.subject_predicates(object_, unique=unique)
+        else:
+            yield from self.impl.subject_predicates(object_, unique=unique)
+
+    def predicate_objects(
+        self, subject: Union[rdf_IdentifiedNode, rdf_Literal, None], unique: bool = False
+    ) -> Generator[tuple, None, None]:
+        if self.locked_context is not None:
+            yield from self.locked_context.predicate_objects(subject, unique=unique)
+        else:
+            yield from self.impl.predicate_objects(subject, unique=unique)
+
+    def subjects(
+        self,
+        predicate: rdf_IdentifiedNode,
+        object_: Union[rdf_IdentifiedNode, rdf_Literal, Sequence[Union[rdf_IdentifiedNode, rdf_Literal]], None],
+        unique: bool = False,
+    ) -> Generator[rdf_IdentifiedNode, None, None]:
+        if isinstance(object_, (list, tuple)):
+            for o in object_:
+                yield from self.subjects(predicate, o, unique=unique)
+            return
+        if self.locked_context is not None:
+            yield from self.locked_context.subjects(predicate, object_, unique=unique)
+        else:
+            yield from self.impl.subjects(predicate, object_, unique=unique)
+
+    def transitive_subjects(
+        self,
+        predicate: rdf_IdentifiedNode,
+        object_: Union[rdf_IdentifiedNode, rdf_Literal, None],
+        remember: Union[Dict[Union[rdf_IdentifiedNode, rdf_Literal], int], None] = None,
+    ):
+        if self.locked_context is not None:
+            yield from self.locked_context.transitive_subjects(predicate, object_, remember=remember)
+        else:
+            yield from self.impl.transitive_subjects(predicate, object_, remember=remember)
+
+    def transitive_objects(
+        self,
+        subject: Union[rdf_IdentifiedNode, rdf_Literal, None],
+        predicate: Union[rdf_IdentifiedNode, None],
+        remember: Union[Dict[Union[rdf_IdentifiedNode, rdf_Literal], int], None] = None,
+    ):
+        if self.locked_context is not None:
+            yield from self.locked_context.transitive_objects(subject, predicate, remember=remember)
+        else:
+            yield from self.impl.transitive_objects(subject, predicate, remember=remember)
+
+    def objects(
+        self,
+        subject: Union[rdf_IdentifiedNode, rdf_Literal, Sequence[Union[rdf_IdentifiedNode, rdf_Literal]], None],
+        predicate: Union[rdf_IdentifiedNode, None],
+        unique: bool = False,
+    ) -> Generator[Union[rdf_IdentifiedNode, rdf_Literal], None, None]:
+        if isinstance(subject, (list, tuple)):
+            for s in subject:
+                yield from self.objects(s, predicate, unique=unique)
+            return
+        if self.locked_context is not None:
+            yield from self.locked_context.objects(subject, predicate, unique=unique)
+        else:
+            yield from self.impl.objects(subject, predicate, unique=unique)
+
+    def with_locked_context(self, identifier: Union[rdf_URIRef, str]) -> "RdfLibDataGraph":
+        if not isinstance(self.impl, rdf_Dataset):
+            raise ValueError("Cannot create a locked context on a non-dataset graph")
+        the_graph = self.impl.get_context(rdf_URIRef(identifier))
+        return RdfLibDataGraph(the_graph.store, the_graph, the_graph)
+
+    def get_context(self, identifier: Union[rdf_URIRef, str]) -> Any:
+        if not isinstance(self.impl, rdf_Dataset):
+            return self.impl  # Just return the graph itself
+        return self.impl.get_context(rdf_URIRef(identifier))  # type: ignore
+
+    def __contains__(
+        self,
+        triple: Tuple[
+            Union[rdf_IdentifiedNode, rdf_Literal, None],
+            Union[rdf_IdentifiedNode, None],
+            Union[rdf_IdentifiedNode, rdf_Literal, None],
+        ],
+    ) -> bool:
+        if self.locked_context is not None:
+            if isinstance(self.impl, rdf_Dataset):
+                quad = (triple[0], triple[1], triple[2], self.locked_context)
+                return quad in self.impl
+            else:
+                return triple in self.locked_context
+        else:
+            return triple in self.impl
+
+    def __len__(self) -> int:
+        if self.locked_context is not None:
+            return len(self.locked_context)
+        else:
+            return len(self.impl)
+
+    def items(self, list_: rdf_IdentifiedNode) -> Generator[Union[rdf_IdentifiedNode, rdf_Literal], None, None]:
+        """Generator over all items in the resource specified by list
+
+        Args:
+            list: An RDF collection.
+        """
+        if self.locked_context is not None:
+            yield from self.locked_context.items(list_)
+        else:
+            yield from self.impl.items(list_)
+
+    def bind(self, prefix: str, namespace: str, **kwargs) -> None:
+        self.impl.bind(prefix, namespace, **kwargs)
+
+
+if has_oxigraph:
+
+    class OxigraphDataGraph(DataGraph):
+        # This acts as kind of a cross between a rdflib.Graph, and rdflib.Dataset and rdflib.Store
+        # It can be used in palce of an rdflib.Graph and rdflib.Dataset
+        # But it can also be used as a Store, in the case of Graph(store=self)
+
+        impl: ox_Store
+        locked_context: Union[ox_NamedNode, None]
+        custom_functions: Dict[ox_NamedNode, Any]
+        custom_aggregate_functions: Dict[ox_NamedNode, Any]
+        _store: 'OxigraphStore'
+        _default_graph: rdf_Graph
+        _namespace_manager: NamespaceManager
+
+        def __init__(
+            self,
+            ox_store: ox_Store,
+            impl: Union[rdf_Dataset, None] = None,
+            locked_context: Union[rdf_Graph, str, None] = None,
+        ):
+            self.impl = ox_store
+            # This is the RDFLib Proxy Store over the Oxigraph Rust Store
+            self._store = OxigraphStore(store=ox_store)
+            rdf_Dataset.__init__(self, store=self._store)
+
+            self._default_union = False
+            if isinstance(locked_context, rdf_Graph):
+                self.locked_context = ox_NamedNode(locked_context.identifier)
+            elif isinstance(locked_context, str):
+                self.locked_context = ox_NamedNode(locked_context)
+            else:
+                self.locked_context = None
+            self._default_graph = rdf_Graph(store=self._store, identifier=DATASET_DEFAULT_GRAPH_ID)
+            self._namespace_manager = NamespaceManager(self._default_graph, bind_namespaces="core")
+            self.custom_functions = {}
+            self.custom_aggregate_functions = {}
+
+        @property
+        def identifier(self) -> str:
+            return "OxigraphStore"
+
+        @property
+        def namespace_manager(self) -> NamespaceManager:
+            return self._namespace_manager
+
+        @classmethod
+        def is_multigraph(cls) -> bool:
+            return True
+
+        @property
+        def store(self) -> Any:
+            return self._store
+
+        def graphs(self, triple: Union[ox_Triple, None] = None) -> Generator[rdf_Graph, None, None]:
+            if triple is not None:
+                raise NotImplementedError("Graphs() on an Oxigraph store are not supported when specifying a triple")
+            yield self._default_graph
+            yield from (from_ox_graph_name(g, self._store) for g in self.impl.named_graphs())
+
+        @property
+        def default_graph(self) -> rdf_Graph:
+            # Not sure how to lock the Oxigraph backing Store to only show the default graph
+            return self._default_graph
+
+        def clone(self, destination: Union[ox_Store, None] = None) -> "OxigraphDataGraph":
+            new_ox_store = clone_oxigraph_store(self.impl, destination)
+            new_dg = OxigraphDataGraph(new_ox_store, None, self.locked_context)
+            new_dg.custom_functions = self.custom_functions.copy()
+            new_dg.custom_aggregate_functions = self.custom_aggregate_functions.copy()
+            return new_dg
+
+        def register_custom_function(
+            self,
+            function_name: rdf_IdentifiedNode,
+            rdflib_fn: Callable,
+            oxigraph_fn: Union[Callable, None] = None,
+            override: bool = False,
+            raw: bool = False,
+            is_aggregate: bool = False,
+        ):
+            if oxigraph_fn is None:
+                return
+            ox_node = to_ox(function_name)
+            if is_aggregate:
+                if ox_node in self.custom_aggregate_functions:
+                    if override:
+                        self.custom_aggregate_functions[ox_node] = oxigraph_fn
+                    else:
+                        pass
+                else:
+                    self.custom_aggregate_functions[ox_node] = oxigraph_fn
+            else:
+                if ox_node in self.custom_functions:
+                    if override:
+                        self.custom_functions[ox_node] = oxigraph_fn
+                    else:
+                        pass
+                else:
+                    self.custom_functions[ox_node] = oxigraph_fn
+
+        def unregister_custom_function(
+            self, function_name: rdf_IdentifiedNode, rdflib_fn: Callable, oxigraph_fn: Union[Callable, None] = None
+        ):
+            ox_node = to_ox(function_name)
+            if ox_node in self.custom_aggregate_functions:
+                del self.custom_aggregate_functions[ox_node]
+            if ox_node in self.custom_functions:
+                del self.custom_functions[ox_node]
+
+        def query_oxigraph(
+            self,
+            query_object: str,
+            initNs: Union[Mapping[str, Any], None] = None,  # noqa: N803
+            initBindings: Union[Mapping[str, Any], None] = None,  # noqa: N803
+            **kwargs: Any,
+        ) -> Union[ox_QueryBoolean, ox_QuerySolutions, ox_QueryTriples]:
+            """Run a SPARQL query and return native pyoxigraph results (no rdflib conversion)."""
+            query_graph = kwargs.get("query_graph", None)
+            ns_map = {**self.store._namespace_for_prefix}
+            if initNs is not None:
+                for ns, uri in initNs.items():
+                    ns_map[ns] = uri
+
+            if initBindings is not None:
+                variable_subs = {ox_Variable(var_uri): term for var_uri, term in initBindings.items()}
+            else:
+                variable_subs = None
+
+            return self.impl.query(
+                query_object,
+                base_iri=None,
+                prefixes=ns_map,
+                use_default_graph_as_union=self._default_union or query_graph == "__UNION__",
+                default_graph=None,
+                named_graphs=None,
+                substitutions=variable_subs,
+                custom_functions=self.custom_functions,
+                custom_aggregate_functions=self.custom_aggregate_functions,
+            )
+
+        def query(
+            self,
+            query_object: Union[str, Query],
+            processor: Union[str, Processor] = "sparql",
+            result: Union[str, Type[Result]] = "sparql",
+            initNs: Union[Mapping[str, Any], None] = None,  # noqa: N803
+            initBindings: Union[Mapping[str, IdentifiedNode], None] = None,  # noqa: N803
+            use_store_provided: bool = True,
+            **kwargs: Any,
+        ) -> Result:
+            if not isinstance(query_object, str):
+                raise ValueError("Query on an Oxigraph store must be a string")
+            ox_bindings = None
+            if initBindings is not None:
+                ox_bindings = {var_uri: to_ox(term) for var_uri, term in initBindings.items()}
+            query_result = self.query_oxigraph(query_object, initNs=initNs, initBindings=ox_bindings, **kwargs)
+            if isinstance(query_result, ox_QueryBoolean):
+                out = Result("ASK")
+                out.askAnswer = bool(query_result)
+            elif isinstance(query_result, ox_QuerySolutions):
+                out = Result("SELECT")
+                out.vars = [rdf_Variable(v.value) for v in query_result.variables]
+                out.bindings = ({v: to_rdf(val) for v, val in zip(out.vars, solution)} for solution in query_result)
+            elif isinstance(query_result, ox_QueryTriples):
+                out = Result("CONSTRUCT")
+                out.graph = rdf_Graph()
+                out.graph += ((to_rdf(t[0]), to_rdf(t[1]), to_rdf(t[2])) for t in query_result)
+            else:
+                raise ValueError(f"Unexpected query result: {query_result}")
+            return out
+
+        def add(
+            self,
+            triple: Tuple[
+                Union[rdf_IdentifiedNode, rdf_Literal],
+                rdf_IdentifiedNode,
+                Union[rdf_Literal, rdf_IdentifiedNode],
+            ],
+            context: Union[rdf_Graph, None] = None,
+            quoted: bool = False,
+        ):
+            if quoted:
+                raise NotImplementedError("Oxigraph store is not formula-aware")
+            if isinstance(triple[1], rdf_BNode) or isinstance(triple[1], rdf_Literal):
+                # Oxigraph does not support BNode or Literal in the predicate position
+                # Cannot add the triple
+                warnings.warn(
+                    "PySHACL rules tried to add a triple with a BNode or Literal in the predicate position",
+                )
+                return
+            if isinstance(triple[0], rdf_Literal):
+                # Oxigraph does not support Literal in the subject position
+                # Cannot add the triple
+                warnings.warn(
+                    "PySHACL rules tried to add a triple with a Literal in the subject position",
+                )
+                return
+            ox_s, ox_p, ox_o = convert_triple_to_oxigraph(triple)
+
+            if self.locked_context is not None:
+                ox_g = self.locked_context
+            elif context is not None:
+                if context.identifier == DATASET_DEFAULT_GRAPH_ID:
+                    ox_g = ox_DefaultGraph()
+                else:
+                    ox_g = to_ox(context.identifier)
+            else:
+                ox_g = ox_DefaultGraph()
+            return self.impl.add(ox_Quad(ox_s, ox_p, ox_o, ox_g))
+
+        def remove(
+            self,
+            triple: Tuple[
+                Union[rdf_IdentifiedNode, rdf_Literal],
+                rdf_IdentifiedNode,
+                Union[rdf_Literal, rdf_IdentifiedNode],
+            ],
+            context: Union[rdf_Graph, None] = None,
+        ):
+            ox_triple = convert_triple_to_oxigraph(triple)
+            if isinstance(ox_triple[1], ox_BlankNode) or isinstance(ox_triple[1], ox_Literal):
+                # Oxigraph does not support BNode or Literal in the predicate position
+                # Cannot remove the triple
+                warnings.warn(
+                    "PySHACL rules tried to remove a triple with a BNode or Literal in the predicate position. This is not supported by Oxigraph.",
+                )
+                return
+            if isinstance(ox_triple[0], ox_Literal):
+                # Oxigraph does not support Literal in the subject position
+                # Cannot remove the triple
+                warnings.warn(
+                    "PySHACL rules tried to remove a triple with a Literal in the subject position. This is not supported by Oxigraph.",
+                )
+                return
+            if self.locked_context is not None:
+                to_remove = list(
+                    self.impl.quads_for_pattern(ox_triple[0], ox_triple[1], ox_triple[2], self.locked_context)
+                )
+            elif context is not None:
+                if context.identifier == DATASET_DEFAULT_GRAPH_ID:
+                    ox_g = ox_DefaultGraph()
+                else:
+                    ox_g = to_ox(context.identifier)
+                to_remove = list(self.impl.quads_for_pattern(ox_triple[0], ox_triple[1], ox_triple[2], ox_g))
+            elif self._default_union:
+                to_remove = list(self.impl.quads_for_pattern(ox_triple[0], ox_triple[1], ox_triple[2], None))
+            else:
+                to_remove = list(
+                    self.impl.quads_for_pattern(ox_triple[0], ox_triple[1], ox_triple[2], ox_DefaultGraph())
+                )
+            for q in to_remove:
+                self.impl.remove(q)
+
+        def triples(
+            self,
+            triple: Tuple[
+                Union[rdf_IdentifiedNode, rdf_Literal, None],
+                Union[rdf_IdentifiedNode, None],
+                Union[rdf_IdentifiedNode, rdf_Literal, None],
+            ],
+        ) -> Generator[
+            Tuple[
+                Union[rdf_IdentifiedNode, rdf_Literal],
+                rdf_IdentifiedNode,
+                Union[rdf_IdentifiedNode, rdf_Literal],
+            ],
+            None,
+            None,
+        ]:
+            ox_triple = convert_triple_to_oxigraph(triple)
+            if isinstance(ox_triple[1], ox_BlankNode) or isinstance(ox_triple[1], ox_Literal):
+                # Oxigraph does not support BNode or Literal in the predicate position
+                # Cannot yield any results
+                return
+            if isinstance(ox_triple[0], ox_Literal):
+                # Oxigraph does not support Literal in the subject position
+                # Cannot yield any results
+                return
+            if self.locked_context is not None:
+                for q in self.impl.quads_for_pattern(ox_triple[0], ox_triple[1], ox_triple[2], self.locked_context):
+                    yield convert_quad_to_rdflib(q)[:3]
+            elif self._default_union:
+                for q in self.impl.quads_for_pattern(ox_triple[0], ox_triple[1], ox_triple[2], None):
+                    yield convert_quad_to_rdflib(q)[:3]
+            else:
+                default_graph = ox_DefaultGraph()
+                for q in self.impl.quads_for_pattern(ox_triple[0], ox_triple[1], ox_triple[2], default_graph):
+                    yield convert_quad_to_rdflib(q)[:3]
+
+        def subject_objects(
+            self, predicate: Union[rdf_IdentifiedNode, None], unique: bool = False
+        ) -> Generator[
+            Tuple[
+                Union[rdf_IdentifiedNode, rdf_Literal],
+                Union[rdf_IdentifiedNode, rdf_Literal],
+            ],
+            None,
+            None,
+        ]:
+            if isinstance(predicate, rdf_BNode) or isinstance(predicate, rdf_Literal):
+                # Oxigraph does not support BNode or Literal in the predicate position
+                # Cannot yield any results
+                return
+            _p = to_ox(predicate)
+            if self.locked_context is not None:
+                for q in self.impl.quads_for_pattern(None, _p, None, self.locked_context):
+                    s, _, o, _ = convert_quad_to_rdflib(q)
+                    yield s, o
+            elif self._default_union:
+                for q in self.impl.quads_for_pattern(None, _p, None, None):
+                    s, _, o, _ = convert_quad_to_rdflib(q)
+                    yield s, o
+            else:
+                for q in self.impl.quads_for_pattern(None, _p, None, ox_DefaultGraph()):
+                    s, _, o, _ = convert_quad_to_rdflib(q)
+                    yield s, o
+
+        def subject_predicates(
+            self, object_: Union[rdf_IdentifiedNode, rdf_Literal, None], unique: bool = False
+        ) -> Generator[Tuple[Union[rdf_IdentifiedNode, rdf_Literal], rdf_IdentifiedNode], None, None]:
+            _o = to_ox(object_)
+            if self.locked_context is not None:
+                for q in self.impl.quads_for_pattern(None, None, _o, self.locked_context):
+                    s, p, _, _ = convert_quad_to_rdflib(q)
+                    yield s, p
+            elif self._default_union:
+                for q in self.impl.quads_for_pattern(None, None, _o, None):
+                    s, p, _, _ = convert_quad_to_rdflib(q)
+                    yield s, p
+            else:
+                for q in self.impl.quads_for_pattern(None, None, _o, ox_DefaultGraph()):
+                    s, p, _, _ = convert_quad_to_rdflib(q)
+                    yield s, p
+
+        def predicate_objects(
+            self, subject: Union[rdf_IdentifiedNode, rdf_Literal, None], unique: bool = False
+        ) -> Generator[Tuple[rdf_IdentifiedNode, Union[rdf_IdentifiedNode, rdf_Literal]], None, None]:
+            _s = to_ox(subject)
+            if self.locked_context is not None:
+                for q in self.impl.quads_for_pattern(_s, None, None, self.locked_context):
+                    _, p, o, _ = convert_quad_to_rdflib(q)
+                    yield p, o
+            elif self._default_union:
+                for q in self.impl.quads_for_pattern(_s, None, None, None):
+                    _, p, o, _ = convert_quad_to_rdflib(q)
+                    yield p, o
+            else:
+                for q in self.impl.quads_for_pattern(_s, None, None, ox_DefaultGraph()):
+                    _, p, o, _ = convert_quad_to_rdflib(q)
+                    yield p, o
+
+        def subjects(
+            self,
+            predicate: rdf_IdentifiedNode,
+            object_: Union[rdf_IdentifiedNode, rdf_Literal, Sequence[Union[rdf_IdentifiedNode, rdf_Literal]], None],
+            unique: bool = False,
+        ) -> Generator[Union[rdf_IdentifiedNode, rdf_Literal], None, None]:
+            if isinstance(object_, (list, tuple)):
+                for o in object_:
+                    yield from self.subjects(predicate, o, unique=unique)
+                return
+            _p = to_ox(predicate)
+            _o = to_ox(object_)
+            if self.locked_context is not None:
+                for s, _, _, _ in self.impl.quads_for_pattern(None, _p, _o, self.locked_context):
+                    yield to_rdf(s)
+            elif self._default_union:
+                for s, _, _, _ in self.impl.quads_for_pattern(None, _p, _o, None):
+                    yield to_rdf(s)
+            else:
+                for s, _, _, _ in self.impl.quads_for_pattern(None, _p, _o, ox_DefaultGraph()):
+                    yield to_rdf(s)
+
+        def transitive_subjects(
+            self,
+            predicate: rdf_IdentifiedNode,
+            object_: Union[rdf_IdentifiedNode, rdf_Literal, None],
+            remember: Union[Dict[Union[rdf_IdentifiedNode, rdf_Literal], int], None] = None,
+        ):
+            if remember is None:
+                remember = {}
+            if object_ in remember:
+                return
+            remember[object_] = 1
+            yield object_
+            for subject in self.subjects(predicate, object_):
+                yield from self.transitive_subjects(predicate, subject, remember)
+
+        def objects(
+            self,
+            subject: Union[rdf_IdentifiedNode, rdf_Literal, Sequence[Union[rdf_IdentifiedNode, rdf_Literal]], None],
+            predicate: Union[rdf_IdentifiedNode, None],
+            unique: bool = False,
+        ) -> Generator[Union[rdf_IdentifiedNode, rdf_Literal], None, None]:
+            if isinstance(subject, (list, tuple)):
+                for s in subject:
+                    yield from self.objects(s, predicate, unique=unique)
+                return
+            _s = to_ox(subject)
+            _p = to_ox(predicate)
+            if self.locked_context is not None:
+                for _, _, o, _ in self.impl.quads_for_pattern(_s, _p, None, self.locked_context):
+                    yield to_rdf(o)
+            elif self._default_union:
+                for _, _, o, _ in self.impl.quads_for_pattern(_s, _p, None, None):
+                    yield to_rdf(o)
+            else:
+                for _, _, o, _ in self.impl.quads_for_pattern(_s, _p, None, ox_DefaultGraph()):
+                    yield to_rdf(o)
+
+        def transitive_objects(
+            self,
+            subject: Union[rdf_IdentifiedNode, rdf_Literal, None],
+            predicate: Union[rdf_IdentifiedNode, None],
+            remember: Union[Dict[Union[rdf_IdentifiedNode, rdf_Literal], int], None] = None,
+        ):
+            if remember is None:
+                remember = {}
+            if subject in remember:
+                return
+            remember[subject] = 1
+            yield subject
+            for object_ in self.objects(subject, predicate):
+                yield from self.transitive_objects(object_, predicate, remember)
+
+        def with_locked_context(self, identifier: Union[rdf_URIRef, str]) -> "OxigraphDataGraph":
+            return OxigraphDataGraph(self.impl, None, str(identifier))
+
+        def get_context(self, identifier: Union[rdf_URIRef, str]) -> Any:
+            return rdf_Graph(store=self._store, identifier=rdf_URIRef(identifier))
+
+        def __contains__(
+            self,
+            triple: Tuple[
+                Union[rdf_IdentifiedNode, rdf_Literal, None],
+                Union[rdf_IdentifiedNode, None],
+                Union[rdf_IdentifiedNode, rdf_Literal, None],
+            ],
+        ) -> bool:
+            if triple[0] is not None and isinstance(triple[0], rdf_Literal):
+                # Oxigraph does not support Literal in the subject position
+                # It cannot exist in the oxigraph store
+                return False
+            triple_ = convert_triple_to_oxigraph(triple)
+            if self.locked_context is not None:
+                quad = ox_Quad(triple_[0], triple_[1], triple_[2], self.locked_context)
+            elif self._default_union:
+                quad = ox_Quad(triple_[0], triple_[1], triple_[2], None)
+            else:
+                quad = ox_Quad(triple_[0], triple_[1], triple_[2], ox_DefaultGraph())
+            return quad in self.impl
+
+        def __len__(self, context: Union[rdf_Graph, None] = None) -> int:
+            default_graph_as_union = context is None or context == "__UNION__" or self._default_union
+            if context is not None:
+                if context.identifier == DATASET_DEFAULT_GRAPH_ID:
+                    default_graph = ox_DefaultGraph()
+                else:
+                    default_graph = to_ox(context.identifier)
+            else:
+                default_graph = None
+            return int(
+                next(
+                    self.impl.query(
+                        "SELECT (COUNT(DISTINCT TRIPLE(?s, ?p, ?o)) AS ?c) WHERE { ?s ?p ?o }",
+                        **(
+                            {"use_default_graph_as_union": True}
+                            if default_graph_as_union
+                            else {"default_graph": default_graph}  # type: ignore[dict-item]
+                        ),
+                    ),
+                )[0].value,
+            )
+
+        def items(self, list_: rdf_IdentifiedNode) -> Generator[Union[rdf_IdentifiedNode, rdf_Literal], None, None]:
+            """Generator over all items in the resource specified by list
+
+            Args:
+                list: An RDF collection.
+            """
+            if isinstance(list_, rdf_URIRef):
+                next_list = ox_NamedNode(str(list_))
+            elif isinstance(list_, rdf_BNode):
+                next_list = ox_BlankNode(str(list_))
+            else:
+                raise ValueError("List must be a URIRef, or BNode")
+            chain = set[ox_NamedNode]([next_list])
+            FIRST = ox_NamedNode(RDF.first)
+            REST = ox_NamedNode(RDF.rest)
+            while next_list:
+                if self.locked_context:
+                    firsts = list(self.impl.quads_for_pattern(next_list, FIRST, None, self.locked_context))
+                else:
+                    firsts = list(self.impl.quads_for_pattern(next_list, FIRST, None, None))
+                if len(firsts) == 0:
+                    item = None
+                else:
+                    item = firsts[0][2]
+                if item is not None:
+                    yield to_rdf(item)
+                if self.locked_context:
+                    rests = list(self.impl.quads_for_pattern(next_list, REST, None, self.locked_context))
+                else:
+                    rests = list(self.impl.quads_for_pattern(next_list, REST, None, None))
+                if len(rests) == 0:
+                    next_list = None
+                else:
+                    next_list = rests[0][2]
+                if next_list in chain:
+                    raise ValueError("List contains a recursive rdf:rest reference")
+                chain.add(next_list)
+
+    class OxigraphStore(rdflib_Store):
+        # OxigraphStore is borrowed from the OxRDFLib poroject
+        # https://github.com/oxigraph/oxrdflib/blob/main/src/oxrdflib/store.py
+
+        context_aware: bool = True
+        formula_aware: bool = False
+        transaction_aware: bool = False
+        graph_aware: bool = True
+
+        def __init__(
+            self,
+            configuration: Union[str, None] = None,
+            identifier: Union[rdf_URIRef, None] = None,
+            *,
+            store: Union[ox_Store, None] = None,
+        ) -> None:
+            self._store = store
+            self._prefix_for_namespace: Dict[rdf_URIRef, str] = {}
+            self._namespace_for_prefix: Dict[str, rdf_URIRef] = {}
+            super().__init__(configuration, identifier)
+
+        def open(self, configuration: str, create: bool = False) -> Union[int, None]:
+            path = Path(configuration)
+            if self._store is not None:
+                raise ValueError("The open function should be called before any RDF operation")
+            if create and path.exists():
+                raise ValueError(f"The directory {configuration} already exist")
+            self._store = ox_Store(configuration)
+            return VALID_STORE
+
+        def close(self, commit_pending_transaction: bool = False) -> None:  # noqa: ARG002
+            del self._store
+
+        def destroy(self, configuration: str) -> None:
+            shutil.rmtree(configuration)
+
+        def gc(self) -> None:
+            pass
+
+        @property
+        def _inner(self) -> ox_Store:
+            if self._store is None:
+                self._store = ox_Store()
+            return self._store
+
+        def add(
+            self,
+            triple: Tuple[
+                Union[rdf_IdentifiedNode, rdf_Literal], rdf_IdentifiedNode, Union[rdf_Literal, rdf_IdentifiedNode]
+            ],
+            context: Union[rdf_Graph, None] = None,
+            quoted: bool = False,
+        ) -> None:
+            if quoted:
+                raise ValueError("Oxigraph stores are not formula aware")
+            ox_triple = convert_triple_to_oxigraph(triple)
+            if context is not None:
+                if context.identifier == DATASET_DEFAULT_GRAPH_ID:
+                    ox_context = ox_DefaultGraph()
+                else:
+                    ox_context = to_ox(context.identifier)
+            else:
+                ox_context = ox_DefaultGraph()
+            self._inner.add(ox_Quad(ox_triple[0], ox_triple[1], ox_triple[2], ox_context))
+            super().add(triple, context, quoted)
+
+        def addN(self, quads: Iterable[tuple]) -> None:  # noqa: N802
+            raise NotImplementedError("addN is not supported by Oxigraph store")
+
+        def remove(
+            self,
+            triple: Tuple[
+                Union[rdf_IdentifiedNode, rdf_Literal, None],
+                Union[rdf_IdentifiedNode, None],
+                Union[rdf_IdentifiedNode, rdf_Literal, None],
+            ],
+            context: Union[rdf_Graph, None] = None,
+        ) -> None:
+            ox_triple = convert_triple_to_oxigraph(triple)
+            if context is not None:
+                if context.identifier == DATASET_DEFAULT_GRAPH_ID:
+                    ox_context = ox_DefaultGraph()
+                else:
+                    ox_context = to_ox(context.identifier)
+            else:
+                ox_context = None
+            for q in self._inner.quads_for_pattern(ox_triple[0], ox_triple[1], ox_triple[2], ox_context):
+                self._inner.remove(q)
+            super().remove(triple, context)
+
+        def triples(
+            self,
+            triple_pattern: Tuple[
+                Union[rdf_IdentifiedNode, rdf_Literal, None],
+                Union[rdf_IdentifiedNode, None],
+                Union[rdf_IdentifiedNode, rdf_Literal, None],
+            ],
+            context: Union[rdf_Graph, None] = None,
+        ) -> Generator[
+            Tuple[
+                Tuple[
+                    Union[rdf_IdentifiedNode, rdf_Literal], rdf_IdentifiedNode, Union[rdf_Literal, rdf_IdentifiedNode]
+                ],
+                Generator[Union[rdf_Graph, None], None, None],
+            ],
+            None,
+            None,
+        ]:
+            try:
+                ox_triple = convert_triple_to_oxigraph(triple_pattern)
+                if context is not None:
+                    if context.identifier == DATASET_DEFAULT_GRAPH_ID:
+                        ox_context = ox_DefaultGraph()
+                    else:
+                        ox_context = to_ox(context.identifier)
+                else:
+                    ox_context = None
+                for q in self._inner.quads_for_pattern(ox_triple[0], ox_triple[1], ox_triple[2], ox_context):
+                    yield (
+                        (to_rdf(q[0]), to_rdf(q[1]), to_rdf(q[2])),
+                        iter(
+                            (from_ox_graph_name(q[3], self),),
+                        ),
+                    )
+            except (TypeError, ValueError):
+                return iter(())  # We just don't return anything
+
+        def __len__(self, context: Union[rdf_Graph, None] = None) -> int:
+            default_graph_as_union = context is None or context == "__UNION__"
+            if context is not None:
+                if context.identifier == DATASET_DEFAULT_GRAPH_ID:
+                    default_graph = ox_DefaultGraph()
+                else:
+                    default_graph = to_ox(context.identifier)
+            else:
+                default_graph = None
+            return int(
+                next(
+                    self._inner.query(
+                        "SELECT (COUNT(DISTINCT TRIPLE(?s, ?p, ?o)) AS ?c) WHERE { ?s ?p ?o }",
+                        **(
+                            {"use_default_graph_as_union": True}
+                            if default_graph_as_union
+                            else {"default_graph": default_graph}  # type: ignore[dict-item]
+                        ),
+                    ),
+                )[0].value,
+            )
+
+        def contexts(self, triple: Union[ox_Triple, None] = None) -> Generator[rdf_Graph, None, None]:
+            if triple is None:
+                return (from_ox_graph_name(g, self) for g in self._inner.named_graphs())
+            raise NotImplementedError("Graphs() on an Oxigraph store are not supported when specifying a triple")
+
+        def query(
+            self,
+            query: Union[Query, str],
+            initNs: Mapping[str, Any],  # noqa: N803
+            initBindings: Mapping[str, rdf_IdentifiedNode],  # noqa: N803
+            queryGraph: str,  # noqa: N803
+            **kwargs: object,
+        ) -> "Result":
+            if isinstance(query, Query):
+                raise NotImplementedError("The already parsed Queries are not supported by Oxigraph store")
+            for kwarg in kwargs:
+                raise NotImplementedError(f"The parameter {kwarg} is not supported by Oxigraph store")
+
+            query_graph = kwargs.get("query_graph", None)
+            ns_map = {**self._prefix_for_namespace}
+            if initNs:
+                for ns, uri in initNs.items():
+                    ns_map[ns] = uri
+
+            if initBindings:
+                variable_subs = {}
+                for var_uri, term in initBindings.items():
+                    variable_subs[ox_Variable(var_uri)] = to_ox(term)
+            else:
+                variable_subs = None
+
+            result: Union[
+                ox_QueryBoolean, Generator[ox_QuerySolutions, None, None], Generator[ox_QueryTriples, None, None]
+            ] = self._inner.query(
+                query,
+                base_iri=None,
+                prefixes=ns_map,
+                use_default_graph_as_union=query_graph == "__UNION__",
+                default_graph=to_ox(queryGraph) if isinstance(queryGraph, rdf_IdentifiedNode) else None,
+                named_graphs=None,
+                substitutions=variable_subs,
+                # custom_functions = self.custom_functions,
+                # custom_aggregate_functions = self.custom_aggregate_functions,
+            )
+            if isinstance(result, ox_QueryBoolean):
+                out = Result("ASK")
+                out.askAnswer = bool(result)
+            elif isinstance(result, ox_QuerySolutions):
+                out = Result("SELECT")
+                out.vars = [rdf_Variable(v.value) for v in result.variables]
+                out.bindings = ({v: to_rdf(val) for v, val in zip(out.vars, solution)} for solution in result)
+            elif isinstance(result, ox_QueryTriples):
+                out = Result("CONSTRUCT")
+                out.graph = rdf_Graph()
+                out.graph += ((to_rdf(t[0]), to_rdf(t[1]), to_rdf(t[2])) for t in result)
+            else:
+                raise ValueError(f"Unexpected query result: {result}")
+            return out
+
+        def update(
+            self,
+            update: Union[Update, str],
+            initNs: Mapping[str, Any],  # noqa: N803
+            initBindings: Mapping[str, rdf_IdentifiedNode],  # noqa: N803
+            queryGraph: str,  # noqa: N803
+            **kwargs: object,
+        ) -> None:
+            if initBindings:
+                raise NotImplementedError("initBindings are not supported by Oxigraph store in update mode")
+            if queryGraph != DATASET_DEFAULT_GRAPH_ID:
+                raise NotImplementedError(f"Only {DATASET_DEFAULT_GRAPH_ID} is supported by native Oxigraph store")
+            if isinstance(update, Update):
+                raise NotImplementedError("The already parsed Updates are not supported by Oxigraph store")
+            for kwarg in kwargs:
+                raise NotImplementedError(f"The parameter {kwarg} is not supported by Oxigraph store")
+            self._inner.update(update, prefixes=dict(self._namespace_for_prefix, **initNs))
+
+        def commit(self) -> None:
+            # TODO: implement
+            pass
+
+        def rollback(self) -> None:
+            # TODO: implement
+            pass
+
+        def add_graph(self, graph: rdf_Graph) -> None:
+            self._inner.add_graph(to_ox(graph))
+
+        def remove_graph(self, graph: rdf_Graph) -> None:
+            self._inner.remove_graph(to_ox(graph))
+
+        def bind(self, prefix: str, namespace: rdf_URIRef, override: bool = True) -> None:
+            if not override and (prefix in self._namespace_for_prefix or namespace in self._prefix_for_namespace):
+                return  # nothing to do
+            self._delete_from_prefix(prefix)
+            self._delete_from_namespace(namespace)
+            self._namespace_for_prefix[prefix] = namespace
+            self._prefix_for_namespace[namespace] = prefix
+
+        def _delete_from_prefix(self, prefix: str) -> None:
+            if prefix not in self._namespace_for_prefix:
+                return
+            namespace = self._namespace_for_prefix[prefix]
+            del self._namespace_for_prefix[prefix]
+            self._delete_from_namespace(namespace)
+
+        def _delete_from_namespace(self, namespace: str) -> None:
+            if namespace not in self._prefix_for_namespace:
+                return
+            prefix = self._prefix_for_namespace[namespace]
+            del self._prefix_for_namespace[namespace]
+            self._delete_from_prefix(prefix)
+
+        def prefix(self, namespace: rdf_URIRef) -> Union[str, None]:
+            return self._prefix_for_namespace.get(namespace)
+
+        def namespace(self, prefix: str) -> Union[rdf_URIRef, None]:
+            return self._namespace_for_prefix.get(prefix)
+
+        def namespaces(self) -> Generator[Tuple[str, rdf_URIRef], None, None]:
+            yield from self._namespace_for_prefix.items()
+
+else:
+
+    class OxigraphDataGraph(DataGraph):
+        def __init__(self, **kwargs) -> None:
+            raise NotImplementedError("pyoxigraph is not installed")
+
+    class OxigraphStore(rdflib_Store):
+        def __init__(self, **kwargs) -> None:
+            raise NotImplementedError("pyoxigraph is not installed")
+
+
+def to_ox(term: Union[rdf_IdentifiedNode, rdf_Literal, None]) -> Union[ox_NamedNode, ox_BlankNode, ox_Literal, None]:
+    if term is None:
+        return None
+    elif term == DATASET_DEFAULT_GRAPH_ID:
+        return ox_DefaultGraph()
+    elif isinstance(term, rdf_BNode):
+        return ox_BlankNode(str(term))
+    elif isinstance(term, rdf_Literal):
+        if term.language is not None:
+            return ox_Literal(str(term), language=term.language)
+        data_type = term.datatype
+        if data_type is not None:
+            data_type = ox_NamedNode(str(data_type))
+        return ox_Literal(str(term), datatype=data_type)
+    elif isinstance(term, rdf_Graph):
+        return to_ox(term.identifier)
+    else:
+        return ox_NamedNode(str(term))
+
+
+def to_rdf(
+    term: Union[ox_NamedNode, ox_BlankNode, ox_Literal, ox_DefaultGraph, None],
+) -> Union[rdf_IdentifiedNode, rdf_Literal, None]:
+    if term is None:
+        return None
+    elif isinstance(term, ox_DefaultGraph):
+        return DATASET_DEFAULT_GRAPH_ID
+    elif isinstance(term, ox_BlankNode):
+        return rdf_BNode(term.value)
+    elif isinstance(term, ox_Literal):
+        if term.language is not None:
+            return rdf_Literal(term.value, lang=term.language)
+        data_type = term.datatype
+        if data_type is not None:
+            data_type = rdf_URIRef(data_type.value)
+        return rdf_Literal(term.value, datatype=data_type)
+    else:
+        return rdf_URIRef(term.value)
+
+
+def convert_quad_to_rdflib(quad: ox_Quad):
+    s, p, o, g = quad
+    if s is None:
+        out_s = None
+    elif isinstance(s, ox_BlankNode):
+        out_s = rdf_BNode(s.value)
+    elif isinstance(s, ox_Literal):
+        # Technically a subject can never be a Literal
+        # in Oxigraph, but this is here for completeness
+        if s.language is not None:
+            out_s = rdf_Literal(s.value, lang=s.language)
+        else:
+            data_type = s.datatype
+            if data_type is not None:
+                data_type = rdf_URIRef(data_type.value)
+            out_s = rdf_Literal(s.value, datatype=data_type)
+    else:
+        out_s = rdf_URIRef(s.value)
+    if p is None:
+        out_p = None
+    elif isinstance(p, ox_BlankNode):
+        out_p = rdf_BNode(p.value)
+    else:
+        out_p = rdf_URIRef(p.value)
+    if o is None:
+        out_o = None
+    elif isinstance(o, ox_Literal):
+        if o.language is not None:
+            out_o = rdf_Literal(o.value, lang=o.language)
+        else:
+            data_type = o.datatype
+            if data_type is not None:
+                data_type = rdf_URIRef(data_type.value)
+            out_o = rdf_Literal(o.value, datatype=data_type)
+    elif isinstance(o, ox_BlankNode):
+        out_o = rdf_BNode(o.value)
+    else:
+        out_o = rdf_URIRef(o.value)
+    if g is None:
+        out_g = None
+    elif isinstance(g, ox_DefaultGraph):
+        out_g = None
+    else:
+        out_g = rdf_URIRef(g.value)
+    return out_s, out_p, out_o, out_g
+
+
+def from_ox_graph_name(
+    graph_name: Union[ox_NamedNode, ox_BlankNode, ox_DefaultGraph],
+    store: rdflib_Store,
+) -> rdf_Graph:
+    if isinstance(graph_name, ox_NamedNode):
+        return rdf_Graph(identifier=rdf_URIRef(graph_name.value), store=store)
+    if isinstance(graph_name, ox_BlankNode):
+        return rdf_Graph(identifier=rdf_BNode(graph_name.value), store=store)
+    if isinstance(graph_name, ox_DefaultGraph):
+        return rdf_Graph(identifier=DATASET_DEFAULT_GRAPH_ID, store=store)
+    raise ValueError(f"Unexpected Oxigraph graph name: {graph_name!r}")
+
+
+def convert_triple_to_oxigraph(
+    triple: Tuple[
+        Union[rdf_IdentifiedNode, rdf_Literal, None],
+        Union[rdf_IdentifiedNode, None],
+        Union[rdf_Literal, rdf_IdentifiedNode, None],
+    ],
+):
+    in_s, in_p, in_o = triple
+
+    if in_s is None:
+        out_s = None
+    elif isinstance(in_s, rdf_BNode):
+        out_s = ox_BlankNode(str(in_s))
+    elif isinstance(in_s, rdf_Literal):
+        if in_s.language is not None:
+            out_s = ox_Literal(str(in_s), language=in_s.language)
+        else:
+            data_type = in_s.datatype
+            if data_type is not None:
+                data_type = ox_NamedNode(str(data_type))
+            out_s = ox_Literal(str(in_s), datatype=data_type)
+    else:
+        out_s = ox_NamedNode(str(in_s))
+    if in_p is None:
+        out_p = None
+    elif isinstance(in_p, rdf_BNode):
+        out_p = ox_BlankNode(str(in_p))
+    else:
+        out_p = ox_NamedNode(str(in_p))
+    if in_o is None:
+        out_o = None
+    elif isinstance(in_o, rdf_BNode):
+        out_o = ox_BlankNode(str(in_o))
+    elif isinstance(in_o, rdf_Literal):
+        if in_o.language is not None:
+            out_o = ox_Literal(str(in_o), language=in_o.language)
+        else:
+            data_type = in_o.datatype
+            if data_type is not None:
+                data_type = ox_NamedNode(str(data_type))
+            out_o = ox_Literal(str(in_o), datatype=data_type)
+    else:
+        out_o = ox_NamedNode(str(in_o))
+    return out_s, out_p, out_o
+
+
+def clone_oxigraph_store(store1: Union[ox_Store], store2: Union[ox_Store, None] = None) -> ox_Store:
+    if store2 is None:
+        store2 = ox_Store()
+    for graph in store1.named_graphs():
+        store2.add_graph(graph)
+    for q in store1.quads_for_pattern(None, None, None, None):
+        store2.add(q)
+    return store2

--- a/pyshacl/helper/sparql_query_helper.py
+++ b/pyshacl/helper/sparql_query_helper.py
@@ -129,9 +129,13 @@ class SPARQLQueryHelper(object):
         prefixes_vals = set(sg.objects(self.node, SH_prefixes))
         if len(prefixes_vals) < 1:
             return
-        named_graph = sg.identifier
-        if named_graph:
-            ng_declares = set(sg.objects(named_graph, SH_declare))
+        if isinstance(sg, rdflib.Dataset):
+            default_graph = sg.default_graph
+            g_name = default_graph.identifier
+        else:
+            g_name = sg.identifier
+        if g_name:
+            ng_declares = set(sg.objects(g_name, SH_declare))
         else:
             ng_declares = set()
         onts = set(sg.subjects(RDF_type, OWL_Ontology))

--- a/pyshacl/pytypes.py
+++ b/pyshacl/pytypes.py
@@ -4,11 +4,10 @@
 from dataclasses import dataclass
 from typing import List, Optional, Union
 
-from rdflib import ConjunctiveGraph, Dataset, Graph, Literal
+from rdflib import Dataset, Graph, Literal
 from rdflib.term import IdentifiedNode, URIRef
 
-ConjunctiveLike = Union[ConjunctiveGraph, Dataset]
-GraphLike = Union[ConjunctiveLike, Graph]
+GraphLike = Union[Dataset, Graph]
 RDFNode = Union[IdentifiedNode, Literal]
 
 

--- a/pyshacl/rdfutil/__init__.py
+++ b/pyshacl/rdfutil/__init__.py
@@ -4,6 +4,5 @@
 
 from .clone import clone_blank_node, clone_graph, clone_literal, clone_node, mix_datasets, mix_graphs  # noqa: F401
 from .compare import compare_blank_node, compare_literal, compare_node, order_graph_literal  # noqa: F401
-from .inoculate import inoculate, inoculate_dataset  # noqa: F401
 from .load import add_baked_in, get_rdf_from_web, load_from_source  # noqa: F401
 from .stringify import stringify_blank_node, stringify_graph, stringify_literal, stringify_node  # noqa: F401

--- a/pyshacl/rdfutil/clone.py
+++ b/pyshacl/rdfutil/clone.py
@@ -4,30 +4,26 @@ from typing import Optional, Union, overload
 
 import rdflib
 from rdflib.collection import Collection
-from rdflib.graph import DATASET_DEFAULT_GRAPH_ID
+from rdflib.graph import DATASET_DEFAULT_GRAPH_ID, Dataset
 from rdflib.namespace import NamespaceManager
 
 from .consts import OWL, RDF_first, RDFNode
-from .pytypes import ConjunctiveLike, GraphLike
+from .pytypes import GraphLike
 
 OWLsameAs = OWL.sameAs
 
 
-def clone_dataset(source_ds: ConjunctiveLike, target_ds=None):
-    if target_ds and not isinstance(target_ds, (rdflib.Dataset, rdflib.ConjunctiveGraph)):
-        raise RuntimeError("when cloning a dataset, the target_ds must be a conjunctiveGraph or rdflib Dataset.")
+def clone_dataset(source_ds: Dataset, target_ds=None):
+    if target_ds and not isinstance(target_ds, rdflib.Dataset):
+        raise RuntimeError("when cloning a dataset, the target_ds must be an rdflib Dataset.")
     default_union = source_ds.default_union
     if target_ds is None:
         target_ds = rdflib.Dataset(default_union=default_union)
         target_ds.namespace_manager = NamespaceManager(target_ds, 'core')
-        target_ds.default_context.namespace_manager = target_ds.namespace_manager
+        target_ds.default_graph.namespace_manager = target_ds.namespace_manager
     named_graphs = [
-        (
-            rdflib.Graph(source_ds.store, i, namespace_manager=source_ds.namespace_manager)  # type: ignore[arg-type]
-            if not isinstance(i, rdflib.Graph)
-            else i
-        )
-        for i in source_ds.store.contexts(None)
+        rdflib.Graph(source_ds.store, i.identifier, namespace_manager=source_ds.namespace_manager)  # type: ignore[arg-type]
+        for i in source_ds.graphs()
     ]
     if isinstance(source_ds, rdflib.Dataset) and len(named_graphs) < 1:
         named_graphs = [
@@ -38,32 +34,32 @@ def clone_dataset(source_ds: ConjunctiveLike, target_ds=None):
         for ng in named_graphs
     ]
     source_graph_identifiers = [ng.identifier for ng in named_graphs]
-    source_default_context_id = source_ds.default_context.identifier
-    target_default_context_id = target_ds.default_context.identifier
-    if source_default_context_id != target_default_context_id:
-        old_target_default_context = target_ds.default_context
-        old_target_default_context_id = old_target_default_context.identifier
+    source_default_graph_id = source_ds.default_graph.identifier
+    target_default_graph_id = target_ds.default_graph.identifier
+    if source_default_graph_id != target_default_graph_id:
+        old_target_default_graph = target_ds.default_graph
+        old_target_default_graph_id = old_target_default_graph.identifier
         if isinstance(target_ds, rdflib.Dataset):
-            new_target_default_context = target_ds.graph(source_default_context_id)
+            new_target_default_graph = target_ds.graph(source_default_graph_id)
         else:
-            new_target_default_context = target_ds.get_context(source_default_context_id)
-            target_ds.store.add_graph(new_target_default_context)
-        target_ds.default_context = new_target_default_context
-        if old_target_default_context_id not in source_graph_identifiers:
+            new_target_default_graph = target_ds.get_context(source_default_graph_id)
+            target_ds.store.add_graph(new_target_default_graph)
+        target_ds.default_graph = new_target_default_graph
+        if old_target_default_graph_id not in source_graph_identifiers:
             if isinstance(target_ds, rdflib.Dataset):
-                target_ds.remove_graph(old_target_default_context)
+                target_ds.remove_graph(old_target_default_graph)
             else:
-                target_ds.store.remove_graph(old_target_default_context)
-        target_default_context_id = new_target_default_context.identifier
+                target_ds.store.remove_graph(old_target_default_graph)
+        target_default_graph_id = new_target_default_graph.identifier
     else:
         if isinstance(target_ds, rdflib.Dataset):
-            _ = target_ds.graph(target_default_context_id)
+            _ = target_ds.graph(target_default_graph_id)
         else:
-            t_default = target_ds.get_context(target_default_context_id)
+            t_default = target_ds.get_context(target_default_graph_id)
             target_ds.store.add_graph(t_default)
 
     for g in cloned_graphs:
-        if g == target_ds.default_context or g.identifier == target_default_context_id:
+        if g == target_ds.default_graph or g.identifier == target_default_graph_id:
             continue
         if isinstance(target_ds, rdflib.Dataset):
             _ = target_ds.graph(g)  # alias to Dataset.add_graph()
@@ -86,7 +82,7 @@ def clone_graph(
     :return: The cloned graph
     :rtype: rdflib.Graph
     """
-    if isinstance(source_graph, (rdflib.Dataset, rdflib.ConjunctiveGraph)):
+    if isinstance(source_graph, rdflib.Dataset):
         return clone_dataset(source_graph, target_ds=target_graph)
     if target_graph is None:
         g = rdflib.Graph(identifier=identifier, bind_namespaces='core')
@@ -101,9 +97,7 @@ def clone_graph(
     return g
 
 
-def mix_datasets(
-    base_ds: ConjunctiveLike, extra_ds: GraphLike, target_ds: Optional[Union[ConjunctiveLike, str]] = None
-):
+def mix_datasets(base_ds: Dataset, extra_ds: GraphLike, target_ds: Optional[Union[Dataset, str]] = None):
     """
     Make a clone of base_ds (dataset) and add in the triples from extra_ds (dataset)
     :param base_ds:
@@ -117,12 +111,8 @@ def mix_datasets(
     """
     default_union = base_ds.default_union
     base_named_graphs = [
-        (
-            rdflib.Graph(base_ds.store, i, namespace_manager=base_ds.namespace_manager)  # type: ignore[arg-type]
-            if not isinstance(i, rdflib.Graph)
-            else i
-        )
-        for i in base_ds.store.contexts(None)
+        rdflib.Graph(base_ds.store, i.identifier, namespace_manager=base_ds.namespace_manager)  # type: ignore[arg-type]
+        for i in base_ds.graphs()
     ]
     if isinstance(base_ds, rdflib.Dataset) and len(base_named_graphs) < 1:
         # rdflib.Dataset always includes the DEFAULT_GRAPH_ID named graph
@@ -133,26 +123,19 @@ def mix_datasets(
     if target_ds is None:
         target_ds = rdflib.Dataset(default_union=default_union)
         target_ds.namespace_manager = NamespaceManager(target_ds, 'core')
-        target_ds.default_context.namespace_manager = target_ds.namespace_manager
+        target_ds.default_graph.namespace_manager = target_ds.namespace_manager
     elif target_ds == "inplace" or target_ds == "base":
         target_ds = base_ds
     elif isinstance(target_ds, str):
         raise RuntimeError("target_ds cannot be a string (unless it is 'inplace' or 'base')")
 
-    if isinstance(target_ds, (rdflib.ConjunctiveGraph, rdflib.Dataset)):
-        if not isinstance(target_ds, rdflib.Dataset):
-            raise RuntimeError("Cannot mix new graphs into a ConjunctiveGraph, use Dataset instead.")
-    else:
+    if not isinstance(target_ds, rdflib.Dataset):
         raise RuntimeError("Cannot mix datasets if target_ds passed in is not a Dataset itself.")
 
-    if isinstance(extra_ds, (rdflib.Dataset, rdflib.ConjunctiveGraph)):
+    if isinstance(extra_ds, rdflib.Dataset):
         mixin_graphs = [
-            (
-                rdflib.Graph(extra_ds.store, i, namespace_manager=extra_ds.namespace_manager)  # type: ignore[arg-type]
-                if not isinstance(i, rdflib.Graph)
-                else i
-            )
-            for i in extra_ds.store.contexts(None)
+            rdflib.Graph(extra_ds.store, i.identifier, namespace_manager=extra_ds.namespace_manager)  # type: ignore[arg-type]
+            for i in extra_ds.graphs()
         ]
     else:
         mixin_graphs = [extra_ds]
@@ -176,31 +159,31 @@ def mix_datasets(
             mixed_graphs.update(mod_named_graphs)
 
         base_graph_identifiers = [bg.identifier for bg in base_named_graphs]
-        base_default_context_id = base_ds.default_context.identifier
-        target_default_context_id = target_ds.default_context.identifier
-        if base_default_context_id != target_default_context_id:
-            old_target_default_context = target_ds.default_context
-            old_target_default_context_id = old_target_default_context.identifier
+        base_default_graph_id = base_ds.default_graph.identifier
+        target_default_graph_id = target_ds.default_graph.identifier
+        if base_default_graph_id != target_default_graph_id:
+            old_target_default_graph = target_ds.default_graph
+            old_target_default_graph_id = old_target_default_graph.identifier
             if isinstance(target_ds, rdflib.Dataset):
-                new_target_default_context = target_ds.graph(base_default_context_id)
+                new_target_default_graph = target_ds.graph(base_default_graph_id)
             else:
-                new_target_default_context = target_ds.get_context(base_default_context_id)
-                target_ds.store.add_graph(new_target_default_context)
-            target_ds.default_context = new_target_default_context
-            if old_target_default_context_id not in base_graph_identifiers:
+                new_target_default_graph = target_ds.get_context(base_default_graph_id)
+                target_ds.store.add_graph(new_target_default_graph)
+            target_ds.default_graph = new_target_default_graph
+            if old_target_default_graph_id not in base_graph_identifiers:
                 if isinstance(target_ds, rdflib.Dataset):
-                    target_ds.remove_graph(old_target_default_context)
+                    target_ds.remove_graph(old_target_default_graph)
                 else:
-                    target_ds.store.remove_graph(old_target_default_context)
-            target_default_context_id = new_target_default_context.identifier
+                    target_ds.store.remove_graph(old_target_default_graph)
+            target_default_graph_id = new_target_default_graph.identifier
         else:
             if isinstance(target_ds, rdflib.Dataset):
-                _ = target_ds.graph(target_default_context_id)
+                _ = target_ds.graph(target_default_graph_id)
             else:
-                t_default = target_ds.get_context(target_default_context_id)
+                t_default = target_ds.get_context(target_default_graph_id)
                 target_ds.store.add_graph(t_default)
         for i, m in mixed_graphs.items():
-            if m == target_ds.default_context or i == target_default_context_id:
+            if m == target_ds.default_context or i == target_default_graph_id:
                 continue
             if isinstance(target_ds, rdflib.Dataset):
                 _ = target_ds.graph(m)  # alias to Dataset.add_graph()
@@ -221,9 +204,7 @@ def mix_graphs(base_graph: GraphLike, extra_graph: GraphLike, target_graph: Opti
     :return: The cloned graph with mixed in triples from extra_graph
     :rtype: rdflib.Graph
     """
-    if isinstance(base_graph, (rdflib.ConjunctiveGraph, rdflib.Dataset)) and isinstance(
-        target_graph, (rdflib.ConjunctiveGraph, rdflib.Dataset)
-    ):
+    if isinstance(base_graph, rdflib.Dataset) and isinstance(target_graph, rdflib.Dataset):
         return mix_datasets(base_graph, extra_graph, target_ds=target_graph)
     if target_graph is None:
         g = clone_graph(base_graph, target_graph=None, identifier=base_graph.identifier)

--- a/pyshacl/rdfutil/consts.py
+++ b/pyshacl/rdfutil/consts.py
@@ -2,7 +2,7 @@
 #
 from typing import Union
 
-from rdflib import RDF, RDFS, ConjunctiveGraph, Dataset, Graph, Namespace
+from rdflib import RDF, RDFS, Dataset, Graph, Namespace
 from rdflib.namespace import OWL
 from rdflib.term import Node
 
@@ -10,8 +10,7 @@ RDFS_Resource = RDFS.Resource
 RDF_first = RDF.first
 SH = Namespace('http://www.w3.org/ns/shacl#')
 
-ConjunctiveLike = Union[ConjunctiveGraph, Dataset]
-GraphLike = Union[ConjunctiveLike, Graph]
+GraphLike = Union[Dataset, Graph]
 RDFNode = Node
 
 OWL_properties = [

--- a/pyshacl/rdfutil/inoculate.py
+++ b/pyshacl/rdfutil/inoculate.py
@@ -3,8 +3,9 @@ from typing import TYPE_CHECKING, Dict, Optional, Union
 
 import rdflib
 
-from .clone import clone_blank_node, clone_dataset, clone_node
-from .consts import OWL, RDF, ConjunctiveLike, GraphLike, OWL_classes, OWL_properties, RDFS_classes, RDFS_properties
+from ..graph_abstraction import DataGraph
+from .clone import clone_blank_node, clone_node
+from .consts import OWL, RDF, GraphLike, OWL_classes, OWL_properties, RDFS_classes, RDFS_properties
 
 if TYPE_CHECKING:
     from rdflib import BNode
@@ -15,7 +16,7 @@ if TYPE_CHECKING:
 OWLNamedIndividual = OWL.NamedIndividual
 
 
-def inoculate(data_graph: rdflib.Graph, ontology: GraphLike) -> rdflib.Graph:
+def inoculate(data_graph: DataGraph, ontology: GraphLike) -> 'DataGraph':
     """
     Copies all RDFS and OWL axioms (classes, relationship definitions, and properties)
     from the ontology graph into the data_graph.
@@ -31,7 +32,7 @@ def inoculate(data_graph: rdflib.Graph, ontology: GraphLike) -> rdflib.Graph:
     ontology_ns = ontology.namespace_manager
     data_graph_ns = data_graph.namespace_manager
 
-    if isinstance(ontology, (rdflib.ConjunctiveGraph, rdflib.Dataset)):
+    if isinstance(ontology, rdflib.Dataset):
         # always set default_union true on the ontology DS
         ontology.default_union = True
     # Bind any missing ontology namespaces in the DataGraph NS manager.
@@ -109,9 +110,9 @@ def inoculate(data_graph: rdflib.Graph, ontology: GraphLike) -> rdflib.Graph:
 
 
 def inoculate_dataset(
-    base_ds: ConjunctiveLike,
+    base_ds: DataGraph,
     ontology_ds: GraphLike,
-    target_ds: Optional[Union[ConjunctiveLike, str]] = None,
+    target_ds: Optional[Union[DataGraph, str]] = None,
     target_graph_identifier: Optional['URIRef'] = None,
 ):
     """
@@ -119,17 +120,17 @@ def inoculate_dataset(
     :param base_ds:
     :type base_ds: rdflib.Dataset
     :param ontology_ds:
-    :type ontology_ds: rdflib.Dataset|rdflib.ConjunctiveGraph|rdflib.Graph
+    :type ontology_ds: rdflib.Dataset|rdflib.Graph
     :param target_ds:
     :type target_ds: rdflib.Dataset|str|NoneType
     :param target_graph_identifier:
     :type target_graph_identifier: rdflib.URIRef | None
     :return: The cloned Dataset with ontology triples from ontology_ds
-    :rtype: rdflib.Dataset
+    :rtype: DataGraph
     """
 
     if target_ds is None:
-        target_ds = clone_dataset(base_ds)
+        target_ds = base_ds.clone()
     elif target_ds is base_ds:
         pass
     elif target_ds == "inplace" or target_ds == "base":
@@ -137,16 +138,13 @@ def inoculate_dataset(
     elif isinstance(target_ds, str):
         raise RuntimeError("target_ds cannot be a string (unless it is 'inplace' or 'base')")
 
-    if isinstance(target_ds, (rdflib.ConjunctiveGraph, rdflib.Dataset)):
-        if not isinstance(target_ds, rdflib.Dataset):
-            raise RuntimeError("Cannot inoculate ConjunctiveGraph, use Dataset instead.")
-    else:
+    if not isinstance(target_ds, DataGraph):
         raise RuntimeError("Cannot inoculate datasets if target_ds passed in is not a Dataset itself.")
 
     if target_graph_identifier:
-        dest_graph = target_ds.get_context(target_graph_identifier)
+        dest_graph = target_ds.with_locked_context(target_graph_identifier)
     else:
-        dest_graph = target_ds.default_context
+        dest_graph = target_ds
 
     # inoculate() routine will set default_union on the ontology_ds if it is a Dataset
     inoculate(dest_graph, ontology_ds)

--- a/pyshacl/rdfutil/load.py
+++ b/pyshacl/rdfutil/load.py
@@ -21,8 +21,7 @@ from .clone import clone_dataset, clone_graph
 
 SCHEMA = SDO
 
-ConjunctiveLike = Union[rdflib.ConjunctiveGraph, rdflib.Dataset]
-GraphLike = Union[ConjunctiveLike, rdflib.Graph]
+GraphLike = Union[rdflib.Dataset, rdflib.Graph]
 
 is_windows = platform.system() == "Windows"
 MAX_OWL_IMPORT_DEPTH = 3
@@ -200,7 +199,7 @@ def load_from_source(
         logger = getLogger("rdfutil.load")
         logger.setLevel(WARNING)
     is_imported_graph = do_owl_imports and isinstance(do_owl_imports, int) and do_owl_imports > 1
-    if isinstance(source, (rdflib.Graph, rdflib.ConjunctiveGraph, rdflib.Dataset)):
+    if isinstance(source, (rdflib.Graph, rdflib.Dataset)):
         source_is_graph = True
         if g is None:
             g = source
@@ -339,22 +338,22 @@ def load_from_source(
         raise ValueError("Cannot determine the format of the input graph")
     if g is None:
         if source_is_graph:
-            target_g: Union[rdflib.Graph, rdflib.ConjunctiveGraph, rdflib.Dataset] = source  # type: ignore
+            target_g: Union[rdflib.Graph, rdflib.Dataset] = source  # type: ignore
         else:
             default_graph_base: Union[str, None] = base_uri if base_uri else (identifier if identifier else None)
             if multigraph:
                 target_ds = rdflib.Dataset(default_graph_base=default_graph_base, default_union=True)
                 target_ds.namespace_manager = NamespaceManager(target_ds, 'core')
                 if identifier:  # if identifier is explicitly given, use that as a new named graph id
-                    old_default_context = target_ds.default_context
-                    if str(old_default_context.identifier) != identifier:
+                    old_default_graph = target_ds.default_graph
+                    if str(old_default_graph.identifier) != identifier:
                         named_g = target_ds.graph(URIRef(identifier))
                         named_g.base = default_graph_base
-                        target_ds.default_context = named_g
-                        target_ds.remove_graph(old_default_context)
+                        target_ds.default_graph = named_g
+                        target_ds.remove_graph(old_default_graph)
                 else:
-                    target_ds.default_context.namespace_manager = target_ds.namespace_manager
-                    default_g = target_ds.default_context
+                    target_ds.default_graph.namespace_manager = target_ds.namespace_manager
+                    default_g = target_ds.default_graph
                     target_ds.graph(default_g)
                 target_g = target_ds
             else:
@@ -365,7 +364,7 @@ def load_from_source(
                 )
 
     else:
-        if not isinstance(g, (rdflib.Graph, rdflib.Dataset, rdflib.ConjunctiveGraph)):
+        if not isinstance(g, (rdflib.Graph, rdflib.Dataset)):
             raise RuntimeError("Passing in 'g' must be a rdflib Graph or Dataset.")
         target_g = g
 
@@ -489,12 +488,12 @@ def load_from_source(
 
         # use base_uri if it is set, otherwise use identifier or _maybe_id
         parser_base_uri: Union[str, None] = base_uri if base_uri else (identifier if identifier else _maybe_id)
-        if isinstance(target_g, (rdflib.Dataset, rdflib.ConjunctiveGraph)):
+        if isinstance(target_g, rdflib.Dataset):
             if identifier:
                 dest_g = target_g.get_context(URIRef(identifier))
                 dest_g.base = parser_base_uri
             else:
-                dest_g = target_g.default_context
+                dest_g = target_g.default_graph
                 dest_g.base = parser_base_uri
             # parsing uses base_uri as the public_id, because it is used for relative URIs
             dest_g.parse(source=cast(IO[bytes], _source), format=rdf_format, publicID=parser_base_uri)
@@ -512,15 +511,15 @@ def load_from_source(
                 # The parser closed our file!
                 pass
         source_is_graph = True
-    elif source_is_graph and (target_g != source):
+    elif source_is_graph and (target_g is not source):
         # clone source into g
-        if isinstance(target_g, (rdflib.Dataset, rdflib.ConjunctiveGraph)) and isinstance(
-            source, (rdflib.Dataset, rdflib.ConjunctiveGraph)
+        if isinstance(target_g, rdflib.Dataset) and isinstance(
+            source, rdflib.Dataset
         ):
             clone_dataset(source, target_g)
-        elif isinstance(target_g, rdflib.Graph) and isinstance(source, (rdflib.Dataset, rdflib.ConjunctiveGraph)):
-            raise RuntimeError("Cannot load a Dataset source into a Graph target.")
-        elif isinstance(target_g, (rdflib.Dataset, rdflib.ConjunctiveGraph)) and isinstance(source, rdflib.Graph):
+        elif isinstance(target_g, rdflib.Graph) and isinstance(source, rdflib.Dataset):
+            raise RuntimeError("Cannot load a Dataset source into a bare Graph target.")
+        elif isinstance(target_g, rdflib.Dataset) and isinstance(source, rdflib.Graph):
             _temp_target = rdflib.Graph(
                 store=target_g.store,
                 identifier=source.identifier if not identifier else URIRef(identifier),
@@ -563,11 +562,11 @@ def load_from_source(
 
         if import_chain is None:
             import_chain = []
-        if isinstance(target_g, (rdflib.Dataset, rdflib.ConjunctiveGraph)):
+        if isinstance(target_g, rdflib.Dataset):
             if identifier:
                 dest_g = target_g.get_context(URIRef(identifier))
             else:
-                dest_g = target_g.default_context
+                dest_g = target_g.default_graph
         else:
             dest_g = target_g
         return chain_load_owl_imports(
@@ -632,7 +631,7 @@ def chain_load_owl_imports(
             _done_imports += 1
         return _done_imports
 
-    if isinstance(target_g, (rdflib.ConjunctiveGraph, rdflib.Dataset)):
+    if isinstance(target_g, rdflib.Dataset):
         # Don't care about named graphs, search across the whole
         # thing at once.
         target_g.default_union = True

--- a/pyshacl/rdfutil/load.py
+++ b/pyshacl/rdfutil/load.py
@@ -512,9 +512,7 @@ def load_from_source(
         source_is_graph = True
     elif source_is_graph and (target_g is not source):
         # clone source into g
-        if isinstance(target_g, rdflib.Dataset) and isinstance(
-            source, rdflib.Dataset
-        ):
+        if isinstance(target_g, rdflib.Dataset) and isinstance(source, rdflib.Dataset):
             clone_dataset(source, target_g)
         elif isinstance(target_g, rdflib.Graph) and isinstance(source, rdflib.Dataset):
             raise RuntimeError("Cannot load a Dataset source into a bare Graph target.")

--- a/pyshacl/rdfutil/pytypes.py
+++ b/pyshacl/rdfutil/pytypes.py
@@ -2,7 +2,6 @@
 #
 from typing import Union
 
-from rdflib import ConjunctiveGraph, Dataset, Graph
+from rdflib import Dataset, Graph
 
-ConjunctiveLike = Union[ConjunctiveGraph, Dataset]
-GraphLike = Union[ConjunctiveLike, Graph]
+GraphLike = Union[Dataset, Graph]

--- a/pyshacl/rdfutil/stringify.py
+++ b/pyshacl/rdfutil/stringify.py
@@ -29,7 +29,7 @@ def with_dict_cache(f):
 def stringify_blank_node(
     graph: rdflib.Graph, bnode: rdflib.BNode, ns_manager: Optional[NamespaceManager] = None, recursion: int = 0
 ):
-    if isinstance(graph, (rdflib.ConjunctiveGraph, rdflib.Dataset)):
+    if isinstance(graph, rdflib.Dataset):
         raise RuntimeError("Can only stringify a blank node when graph is a rdflib.Graph")
     assert isinstance(graph, rdflib.Graph)
     assert isinstance(bnode, rdflib.BNode)
@@ -124,7 +124,7 @@ def stringify_literal(graph: rdflib.Graph, node: rdflib.Literal, ns_manager: Opt
     return node_string
 
 
-def find_node_named_graph(dataset: Union[rdflib.Dataset, rdflib.ConjunctiveGraph], node) -> rdflib.Graph:
+def find_node_named_graph(dataset: rdflib.Dataset, node) -> rdflib.Graph:
     """
     Search through each graph in a dataset for one node, when it finds it, returns the graph it is in
     :param dataset:
@@ -164,7 +164,7 @@ def stringify_node(
     if ns_manager is None:
         ns_manager = graph.namespace_manager
     if isinstance(ns_manager, rdflib.Graph):
-        # json-ld loader can set namespace_manager to the conjunctive graph itself.
+        # json-ld loader can set namespace_manager to the Dataset itself.
         ns_manager = ns_manager.namespace_manager
     if ns_manager is None or isinstance(ns_manager, rdflib.Graph):
         raise RuntimeError("Cannot stringify node, no namespaces known.")
@@ -172,7 +172,7 @@ def stringify_node(
     if isinstance(node, rdflib.Literal):
         return stringify_literal(graph, node, ns_manager=ns_manager)
     if isinstance(node, rdflib.BNode):
-        if isinstance(graph, (rdflib.ConjunctiveGraph, rdflib.Dataset)):
+        if isinstance(graph, rdflib.Dataset):
             graph = find_node_named_graph(graph, node)
         return stringify_blank_node(graph, node, ns_manager=ns_manager, recursion=recursion + 1)
     if isinstance(node, rdflib.URIRef):

--- a/pyshacl/rule_expand_runner.py
+++ b/pyshacl/rule_expand_runner.py
@@ -12,11 +12,9 @@ from .consts import (
 )
 from .extras import check_extra_installed
 from .functions import apply_functions, gather_functions, unapply_functions
+from .graph_abstraction import DataGraph, clone_oxigraph_store, has_oxigraph, ox_Store
 from .pytypes import GraphLike, SHACLExecutor
 from .rdfutil import (
-    clone_graph,
-    inoculate,
-    inoculate_dataset,
     mix_datasets,
     mix_graphs,
 )
@@ -29,9 +27,18 @@ USE_FULL_MIXIN = getenv("PYSHACL_USE_FULL_MIXIN") in env_truths
 
 
 class RuleExpandRunner(PySHACLRunType):
+    data_graph: DataGraph
+    ont_graph: Optional[GraphLike]
+    shacl_graph: ShapesGraph
+    logger: logging.Logger
+    debug: bool
+    pre_inferenced: bool
+    inplace: bool
+    options: Dict[str, Any]
+
     def __init__(
         self,
-        data_graph: GraphLike,
+        data_graph: DataGraph,
         *args,
         shacl_graph: Optional[GraphLike] = None,
         ont_graph: Optional[GraphLike] = None,
@@ -41,20 +48,25 @@ class RuleExpandRunner(PySHACLRunType):
         options = options or {}
         self._load_default_options(options)
         self.options = options  # type: dict
-        self.logger = options['logger']  # type: logging.Logger
+        self.logger = options['logger']
         self.debug = options['debug']
         self.pre_inferenced = kwargs.pop('pre_inferenced', False)
         self.inplace = options['inplace']
-        if not isinstance(data_graph, rdflib.Graph):
-            raise RuntimeError("data_graph must be a rdflib Graph-like object")
-        self.data_graph = data_graph  # type: GraphLike
+        if not isinstance(data_graph, DataGraph):
+            raise RuntimeError("data_graph must be a DataGraph object")
+        self.data_graph: DataGraph = data_graph
         self._target_graph: Union[GraphLike, None] = None
-        self.ont_graph = ont_graph  # type: Optional[GraphLike]
-        self.data_graph_is_multigraph = isinstance(self.data_graph, (rdflib.Dataset, rdflib.ConjunctiveGraph))
-        if self.ont_graph is not None and isinstance(self.ont_graph, (rdflib.Dataset, rdflib.ConjunctiveGraph)):
+        self.ont_graph = ont_graph
+        self.data_graph_is_multigraph = self.data_graph.is_multigraph()
+        if self.ont_graph is not None and isinstance(self.ont_graph, rdflib.Dataset):
             self.ont_graph.default_union = True
         if shacl_graph is None:
-            shacl_graph = clone_graph(data_graph, identifier='shacl')
+            if has_oxigraph and isinstance(data_graph.impl, ox_Store):
+                ox2 = clone_oxigraph_store(data_graph.impl)
+                shacl_graph = DataGraph.from_oxigraph_store(ox2)
+                shacl_graph.default_union = True
+            else:
+                shacl_graph = data_graph.clone(identifier='shacl')
         assert isinstance(shacl_graph, rdflib.Graph), "shacl_graph must be a rdflib Graph object"
         self.shacl_graph = ShapesGraph(shacl_graph, self.debug, self.logger)  # type: ShapesGraph
 
@@ -86,11 +98,14 @@ class RuleExpandRunner(PySHACLRunType):
             if not self.data_graph_is_multigraph:
                 return mix_graphs(self.data_graph, self.ont_graph, "inplace" if self.inplace else None)
             return mix_datasets(self.data_graph, self.ont_graph, "inplace" if self.inplace else None)
+        # Lazy import to avoid circular import
+        from .rdfutil.inoculate import inoculate, inoculate_dataset
+
         if not self.data_graph_is_multigraph:
             if self.inplace:
                 to_graph = self.data_graph
             else:
-                to_graph = clone_graph(self.data_graph, identifier=self.data_graph.identifier)
+                to_graph = self.data_graph.clone()
             return inoculate(to_graph, self.ont_graph)
         return inoculate_dataset(
             self.data_graph,
@@ -113,8 +128,8 @@ class RuleExpandRunner(PySHACLRunType):
             debug=self.debug,
         )
 
-    def run(self) -> GraphLike:
-        datagraph: Union[GraphLike, None] = self.target_graph
+    def run(self) -> DataGraph:
+        datagraph: Union[DataGraph, None] = self.target_graph
         if datagraph is not None:
             # Target graph is already set up with pre-inferenced and pre-cloned data_graph
             self._target_graph = datagraph
@@ -136,7 +151,7 @@ class RuleExpandRunner(PySHACLRunType):
             if inference_option and not self.pre_inferenced and str(inference_option) != "none":
                 if not has_cloned and not self.inplace:
                     self.logger.debug("Cloning DataGraph to temporary memory graph before pre-inferencing.")
-                    datagraph = clone_graph(datagraph)
+                    datagraph = datagraph.clone()
                     has_cloned = True
                 self.logger.debug(f"Running pre-inferencing with option='{inference_option}'.")
                 self._run_pre_inference(
@@ -148,7 +163,7 @@ class RuleExpandRunner(PySHACLRunType):
                 self.logger.debug(
                     "Forcing clone of DataGraph because expanding rules cannot modify the input datagraph."
                 )
-                datagraph = clone_graph(datagraph)
+                datagraph = datagraph.clone()
                 has_cloned = True
             self._target_graph = datagraph
         assert self._target_graph is not None
@@ -213,10 +228,10 @@ class RuleExpandRunner(PySHACLRunType):
         for s in shapes:
             s.set_advanced(True)
         apply_target_types(target_types)
-        if isinstance(self._target_graph, (rdflib.Dataset, rdflib.ConjunctiveGraph)):
+        if self._target_graph.is_multigraph():
             self._target_graph.default_union = True
 
-        g = self._target_graph
+        g: DataGraph = self._target_graph
 
         if specified_focus_nodes is not None and using_manually_specified_shapes:
             on_focus_nodes: Union[Sequence[URIRef], None] = specified_focus_nodes

--- a/pyshacl/rules/__init__.py
+++ b/pyshacl/rules/__init__.py
@@ -4,16 +4,16 @@ from typing import TYPE_CHECKING, Any, Dict, List, Sequence, Tuple, Type, Union
 
 from rdflib import BNode, URIRef
 
-from pyshacl.consts import RDF_type, SH_rule, SH_SPARQLRule, SH_TripleRule
-from pyshacl.errors import ReportableRuntimeError, RuleLoadError
-from pyshacl.pytypes import GraphLike, RDFNode, SHACLExecutor
-from pyshacl.rules.sparql import SPARQLRule
-from pyshacl.rules.triple import TripleRule
+from ..consts import RDF_type, SH_rule, SH_SPARQLRule, SH_TripleRule
+from ..errors import ReportableRuntimeError, RuleLoadError
+from ..pytypes import RDFNode, SHACLExecutor
+from ..rules.sparql import SPARQLRule
+from ..rules.triple import TripleRule
 
 if TYPE_CHECKING:
-    from pyshacl.shape import Shape
-    from pyshacl.shapes_graph import ShapesGraph
-
+    from ..graph_abstraction import DataGraph
+    from ..shape import Shape
+    from ..shapes_graph import ShapesGraph
     from .shacl_rule import SHACLRule
 
 
@@ -92,7 +92,7 @@ RULES_ITERATE_LIMIT = 100
 def apply_rules(
     executor: SHACLExecutor,
     shapes_rules: Dict,
-    data_graph: GraphLike,
+    data_graph: 'DataGraph',
     focus_nodes: Union[Sequence[RDFNode], None] = None,
 ) -> int:
     # short the shapes dict by shapes sh:order before execution

--- a/pyshacl/rules/sparql/__init__.py
+++ b/pyshacl/rules/sparql/__init__.py
@@ -15,7 +15,8 @@ from ..shacl_rule import SHACLRule
 if TYPE_CHECKING:
     from rdflib.term import URIRef
 
-    from pyshacl.pytypes import GraphLike, RDFNode, SHACLExecutor
+    from pyshacl.graph_abstraction import DataGraph
+    from pyshacl.pytypes import RDFNode, SHACLExecutor
     from pyshacl.shape import Shape
 
 XSD_string = XSD.string
@@ -55,7 +56,7 @@ class SPARQLRule(SHACLRule):
 
     def apply(
         self,
-        data_graph: 'GraphLike',
+        data_graph: 'DataGraph',
         focus_nodes: Optional[Sequence['RDFNode']] = None,
         target_graph_identifier: Optional['URIRef'] = None,
     ) -> int:
@@ -108,11 +109,11 @@ class SPARQLRule(SHACLRule):
                         added += 1
                         construct_graphs.add(result_graph)
             if added > 0:
-                if isinstance(data_graph, (rdflib.Dataset, rdflib.ConjunctiveGraph)):
+                if data_graph.is_multigraph():
                     if target_graph_identifier is not None:
                         target_graph = data_graph.get_context(target_graph_identifier)
                     else:
-                        target_graph = data_graph.default_context
+                        target_graph = data_graph.default_graph
                 else:
                     target_graph = data_graph
                 for g in construct_graphs:

--- a/pyshacl/rules/triple/__init__.py
+++ b/pyshacl/rules/triple/__init__.py
@@ -97,11 +97,11 @@ class TripleRule(SHACLRule):
                 if this_added:
                     added += 1
             if added > 0:
-                if isinstance(data_graph, (rdflib.Dataset, rdflib.ConjunctiveGraph)):
+                if isinstance(data_graph, rdflib.Dataset):
                     if target_graph_identifier is not None:
                         target_graph = data_graph.get_context(target_graph_identifier)
                     else:
-                        target_graph = data_graph.default_context
+                        target_graph = data_graph.default_graph
                 else:
                     target_graph = data_graph
                 for i in to_add:

--- a/pyshacl/run_type.py
+++ b/pyshacl/run_type.py
@@ -2,14 +2,12 @@ import logging
 from abc import ABCMeta, abstractmethod
 from typing import TYPE_CHECKING, Optional
 
-import rdflib
-
-from pyshacl.errors import ReportableRuntimeError
+from .errors import ReportableRuntimeError
 
 if TYPE_CHECKING:
     from rdflib.term import URIRef
 
-    from pyshacl.pytypes import GraphLike
+    from .graph_abstraction import DataGraph
 
 
 class PySHACLRunType(metaclass=ABCMeta):
@@ -22,7 +20,7 @@ class PySHACLRunType(metaclass=ABCMeta):
     @classmethod
     def _run_pre_inference(
         cls,
-        target_graph: 'GraphLike',
+        target_graph: 'DataGraph',
         inference_option: str,
         destination_graph_identifier: Optional['URIRef'] = None,
         logger: Optional[logging.Logger] = None,
@@ -31,7 +29,7 @@ class PySHACLRunType(metaclass=ABCMeta):
         Note, this is the OWL/RDFS pre-inference,
         it is not the Advanced Spec SHACL-Rule inferencing step.
         :param target_graph:
-        :type target_graph: rdflib.Graph|rdflib.ConjunctiveGraph|rdflib.Dataset
+        :type target_graph: rdflib.Graph|rdflib.Dataset
         :param inference_option:
         :type inference_option: str
         :return:
@@ -39,6 +37,7 @@ class PySHACLRunType(metaclass=ABCMeta):
         """
         # Lazy import owlrl
         import owlrl
+        from owlrl.graph_abstraction import DataGraph as OWLDataGraph
 
         from .inference import CustomRDFSOWLRLSemantics, CustomRDFSSemantics
 
@@ -60,16 +59,26 @@ class PySHACLRunType(metaclass=ABCMeta):
             raise ReportableRuntimeError(
                 "Error during creation of OWL-RL Deductive Closure\n{}".format(str(e.args[0]))
             )
-        if isinstance(target_graph, (rdflib.Dataset, rdflib.ConjunctiveGraph)):
+        if target_graph.is_oxigraph:
+            ox_store = target_graph.impl
+            owl_target = OWLDataGraph(ox_store)
+        else:
+            owl_target = target_graph.impl
+        if target_graph.is_multigraph():
             target_graph.default_union = True
             if destination_graph_identifier is not None:
-                destination_graph = target_graph.get_context(destination_graph_identifier)
+                if target_graph.is_oxigraph:
+                    ox_store = target_graph.impl
+                    owl_dest = OWLDataGraph(ox_store, locked_context=destination_graph_identifier)
+                else:
+                    rdf_graph = target_graph.impl.get_context(destination_graph_identifier)
+                    owl_dest = rdf_graph
             else:
-                destination_graph = target_graph.default_context
+                owl_dest = target_graph.default_graph
         else:
-            destination_graph = None
+            owl_dest = None
         try:
-            inferencer.expand(target_graph, destination=destination_graph)
+            inferencer.expand(owl_target, destination=owl_dest)
         except Exception as e:  # pragma: no cover
             raise
             logger.error("Error while running OWL-RL Deductive Closure")

--- a/pyshacl/shapes_graph.py
+++ b/pyshacl/shapes_graph.py
@@ -47,7 +47,7 @@ class ShapesGraph(object):
         :param logger:
         :type logger: logging.Logger|None
         """
-        assert isinstance(graph, (rdflib.Dataset, rdflib.ConjunctiveGraph, rdflib.Graph))
+        assert isinstance(graph, (rdflib.Dataset, rdflib.Graph))
         self.graph = graph
         if isinstance(self.graph, rdflib.Dataset):
             self.graph.default_union = True
@@ -72,8 +72,8 @@ class ShapesGraph(object):
         return bool(self._use_js)
 
     def _add_system_triples(self):
-        if isinstance(self.graph, (rdflib.Dataset, rdflib.ConjunctiveGraph)):
-            g = self.graph.default_context
+        if isinstance(self.graph, rdflib.Dataset):
+            g = self.graph.default_graph
         else:
             g = self.graph
         for t in self.system_triples:

--- a/pyshacl/validator.py
+++ b/pyshacl/validator.py
@@ -18,13 +18,11 @@ from .consts import (
 from .errors import ReportableRuntimeError
 from .extras import check_extra_installed
 from .functions import apply_functions, gather_functions, unapply_functions
+from .graph_abstraction import DataGraph, clone_oxigraph_store, has_oxigraph, ox_Store
 from .pytypes import GraphLike, SHACLExecutor
 from .rdfutil import (
     add_baked_in,
     clone_blank_node,
-    clone_graph,
-    inoculate,
-    inoculate_dataset,
     mix_datasets,
     mix_graphs,
 )
@@ -37,9 +35,18 @@ USE_FULL_MIXIN = getenv("PYSHACL_USE_FULL_MIXIN") in env_truths
 
 
 class Validator(PySHACLRunType):
+    data_graph: DataGraph
+    ont_graph: Optional[GraphLike]
+    shacl_graph: ShapesGraph
+    logger: logging.Logger
+    debug: bool
+    pre_inferenced: bool
+    inplace: bool
+    options: Dict[str, Any]
+
     def __init__(
         self,
-        data_graph: GraphLike,
+        data_graph: DataGraph,
         *args,
         shacl_graph: Optional[GraphLike] = None,
         ont_graph: Optional[GraphLike] = None,
@@ -48,18 +55,18 @@ class Validator(PySHACLRunType):
     ):
         options = options or {}
         self._load_default_options(options)
-        self.options = options  # type: dict
-        self.logger = options['logger']  # type: logging.Logger
+        self.options = options
+        self.logger = options['logger']
         self.debug = options['debug']
         self.pre_inferenced = kwargs.pop('pre_inferenced', False)
         self.inplace = options['inplace']
-        if not isinstance(data_graph, rdflib.Graph):
-            raise RuntimeError("data_graph must be a rdflib Graph object")
-        self.data_graph = data_graph  # type: GraphLike
-        self._target_graph: Union[GraphLike, None] = None
-        self.ont_graph = ont_graph  # type: Optional[GraphLike]
-        self.data_graph_is_multigraph = isinstance(self.data_graph, (rdflib.Dataset, rdflib.ConjunctiveGraph))
-        if self.ont_graph is not None and isinstance(self.ont_graph, (rdflib.Dataset, rdflib.ConjunctiveGraph)):
+        if not isinstance(data_graph, DataGraph):
+            raise RuntimeError("data_graph must be a DataGraph object")
+        self.data_graph = data_graph
+        self._target_graph: Union[DataGraph, None] = None
+        self.ont_graph = ont_graph
+        self.data_graph_is_multigraph = self.data_graph.is_multigraph()
+        if self.ont_graph is not None and isinstance(self.ont_graph, rdflib.Dataset):
             self.ont_graph.default_union = True
         if self.ont_graph is not None and options['sparql_mode']:
             raise ReportableRuntimeError("Cannot use SPARQL Remote Graph Mode with extra Ontology Graph inoculation.")
@@ -68,9 +75,14 @@ class Validator(PySHACLRunType):
                 raise ReportableRuntimeError(
                     "SHACL Shapes Graph must be a separate local graph or file when in SPARQL Remote Graph Mode."
                 )
-            shacl_graph = clone_graph(data_graph, identifier='shacl')
+            if has_oxigraph and isinstance(data_graph.impl, ox_Store):
+                ox2 = clone_oxigraph_store(data_graph.impl)
+                shacl_graph = DataGraph.from_oxigraph_store(ox2)
+                shacl_graph.default_union = True
+            else:
+                shacl_graph = data_graph.clone(identifier='shacl')
         assert isinstance(shacl_graph, rdflib.Graph), "shacl_graph must be a rdflib Graph object"
-        self.shacl_graph = ShapesGraph(shacl_graph, self.debug, self.logger)  # type: ShapesGraph
+        self.shacl_graph = ShapesGraph(shacl_graph, self.debug, self.logger)
 
         if options['use_js']:
             if options['sparql_mode']:
@@ -148,11 +160,14 @@ class Validator(PySHACLRunType):
             if not self.data_graph_is_multigraph:
                 return mix_graphs(self.data_graph, self.ont_graph, "inplace" if self.inplace else None)
             return mix_datasets(self.data_graph, self.ont_graph, "inplace" if self.inplace else None)
+        # Lazy import to avoid circular import
+        from .rdfutil.inoculate import inoculate, inoculate_dataset
+
         if not self.data_graph_is_multigraph:
             if self.inplace:
                 to_graph = self.data_graph
             else:
-                to_graph = clone_graph(self.data_graph, identifier=self.data_graph.identifier)
+                to_graph = self.data_graph.clone()
             return inoculate(to_graph, self.ont_graph)
         return inoculate_dataset(
             self.data_graph,
@@ -176,7 +191,7 @@ class Validator(PySHACLRunType):
         )
 
     def run(self):
-        datagraph: Union[GraphLike, None] = self.target_graph
+        datagraph: Union[DataGraph, None] = self.target_graph
         if datagraph is not None:
             self._target_graph = datagraph
         else:
@@ -199,7 +214,7 @@ class Validator(PySHACLRunType):
                     raise ReportableRuntimeError("Cannot use any pre-inference option in SPARQL Remote Graph Mode.")
                 if not has_cloned and not self.inplace:
                     self.logger.debug("Cloning DataGraph to temporary memory graph before pre-inferencing.")
-                    datagraph = clone_graph(datagraph)
+                    datagraph = datagraph.clone()
                     has_cloned = True
                 self.logger.debug(f"Running pre-inferencing with option='{inference_option}'.")
                 self._run_pre_inference(
@@ -211,7 +226,7 @@ class Validator(PySHACLRunType):
                     raise ReportableRuntimeError("Cannot clone DataGraph in SPARQL Remote Graph Mode.")
                 # We still need to clone in advanced mode, because of triple rules
                 self.logger.debug("Forcing clone of DataGraph because advanced mode is enabled.")
-                datagraph = clone_graph(datagraph)
+                datagraph = datagraph.clone()
                 has_cloned = True
             if not has_cloned and not self.inplace:
                 # No inferencing, no ont_graph, and no advanced mode, now implies inplace mode
@@ -298,10 +313,10 @@ class Validator(PySHACLRunType):
                 "Abort on first error is enabled. Will exit at end of first Shape that fails validation."
             )
 
-        if isinstance(self._target_graph, (rdflib.Dataset, rdflib.ConjunctiveGraph)):
+        if self._target_graph.is_multigraph():
             self._target_graph.default_union = True
 
-        g = self._target_graph
+        g: DataGraph = self._target_graph
 
         if self.debug:
             self.logger.debug(f"Validating DataGraph named {g.identifier}")

--- a/pyshacl/validator_conformance.py
+++ b/pyshacl/validator_conformance.py
@@ -408,7 +408,7 @@ def check_dash_result(
     was_default_union = None
     if log is None:
         log = logging.getLogger(__name__)
-    if isinstance(expected_result_graph, (rdflib.ConjunctiveGraph, rdflib.Dataset)):
+    if isinstance(expected_result_graph, rdflib.Dataset):
         was_default_union = expected_result_graph.default_union
         expected_result_graph.default_union = True  # Force default-union to make all of this a bit easier
     gv_test_cases = expected_result_graph.subjects(RDF_type, DASH_GraphValidationTestCase)
@@ -436,8 +436,10 @@ def check_dash_result(
     if len(inf_test_cases_set) > 0:
         data_graph = validator.target_graph
         assert data_graph is not None
-        if isinstance(data_graph, (rdflib.ConjunctiveGraph, rdflib.Dataset)):
-            named_graphs = list(data_graph.contexts())
+        if isinstance(data_graph, rdflib.Dataset):
+            named_graphs = list(data_graph.graphs())
+            if len(named_graphs) < 1:
+                named_graphs = [data_graph]
             was_union: Union[bool, None] = data_graph.default_union
             data_graph.default_union = True
         else:

--- a/test/test_advanced.py
+++ b/test/test_advanced.py
@@ -4,10 +4,14 @@ SHACL Functions (implemented as SPARQL functions)
 SHACL Rules
 Node Expressions
 Expression Constraint
+SPARQL constraints that call SHACL Functions as SPARQL extension functions
 """
 
+from typing import Tuple, Union
 from pyshacl import validate
 from rdflib import Graph
+
+from pyshacl.graph_abstraction import has_oxigraph
 
 shacl_file = '''\
 # prefix: ex
@@ -24,6 +28,14 @@ shacl_file = '''\
 <http://datashapes.org/shasf/tests/expression/advanced.test.shacl>
   rdf:type owl:Ontology ;
   rdfs:label "Test of advanced features" ;
+  sh:declare [
+    sh:prefix "ex" ;
+    sh:namespace "http://datashapes.org/shasf/tests/expression/advanced.test.shacl#" ;
+  ] ;
+  sh:declare [
+    sh:prefix "exOnt" ;
+    sh:namespace "http://datashapes.org/shasf/tests/expression/advanced.test.ont#" ;
+  ] ;
 .
 
 ex:concat
@@ -41,7 +53,7 @@ ex:concat
     ] ;
     sh:returnType xsd:string ;
     sh:select """
-        SELECT ?result
+        SELECT ?result ?op1 ?op2
         WHERE {
           BIND(CONCAT(STR(?op1),STR(?op2)) AS ?result) .
         }
@@ -57,7 +69,7 @@ ex:strlen
     ] ;
     sh:returnType xsd:integer ;
     sh:select """
-        SELECT ?result
+        SELECT ?result ?op1
         WHERE {
           BIND(STRLEN(?op1) AS ?result) .
         }
@@ -78,7 +90,7 @@ ex:lessThan
     ] ;
     sh:returnType xsd:boolean ;
     sh:select """
-        SELECT ?result
+        SELECT ?result ?op1 ?op2
         WHERE {
           BIND(IF(?op1 < ?op2, true, false) AS ?result) .
         }
@@ -95,6 +107,24 @@ ex:PersonExpressionShape
             ]
             35 );
     ] .
+
+ex:PersonSparqlFunctionShape
+    a sh:NodeShape ;
+    sh:targetClass exOnt:Person ;
+    sh:sparql ex:PersonFullNameLength-sparql .
+
+ex:PersonFullNameLength-sparql
+    a sh:SPARQLConstraintObject ;
+    sh:prefixes <http://datashapes.org/shasf/tests/expression/advanced.test.shacl> ;
+    sh:message "Person full name must be under 35 characters (SPARQL custom function path)." ;
+    sh:select """
+        SELECT $this
+        WHERE {
+            $this exOnt:firstName ?firstName .
+            $this exOnt:lastName ?lastName .
+            FILTER (STRLEN(ex:concat(?firstName, ?lastName)) >= 35)
+        }
+        """ .
 
 ex:PersonRuleShape
 	a sh:NodeShape ;
@@ -129,6 +159,12 @@ ex:Jenny
   exOnt:firstName "Jennifer" ;
   exOnt:lastName "Wolfeschlegelsteinhausenbergerdorff" ;
 .
+
+ex:Bob
+  rdf:type exOnt:Person ;
+  exOnt:firstName "Robert" ;
+  exOnt:lastName "Bartholomew-Williamson-Jefferson-III" ;
+.
 '''
 
 
@@ -138,6 +174,43 @@ def test_advanced():
     conforms, report, message = validate(d, shacl_graph=s, advanced=True, debug=False)
     print(message)
     assert not conforms
+
+if has_oxigraph:
+    def test_advanced_sparql_custom_function():
+        """Validate SPARQL constraints that invoke SHACL Functions as SPARQL extension functions.
+
+        Unlike node-expression evaluation (which calls SPARQLFunction.execute() in Python), this
+        path registers custom functions and invokes execute_from_sparql / execute_from_sparql_oxigraph
+        from inside the SPARQL engine when a constraint query contains calls like ex:concat(...).
+        """
+        import pyoxigraph as ox
+        from pyoxigraph import RdfFormat, NamedNode, BlankNode, Literal
+
+        from pyshacl.functions.shacl_function import SPARQLFunction
+
+        oxigraph_sparql_fn_calls = []
+        orig = SPARQLFunction.execute_from_sparql_oxigraph
+
+        def recording_execute_from_sparql_oxigraph(self, g, *args: Tuple[Union[NamedNode, BlankNode, Literal], ...]):
+            oxigraph_sparql_fn_calls.append(self.node)
+            return orig(self, g, *args)
+
+        SPARQLFunction.execute_from_sparql_oxigraph = recording_execute_from_sparql_oxigraph
+        try:
+            d = ox.Store()
+            d.bulk_load(data_graph, format=RdfFormat.TURTLE)
+            s = Graph().parse(data=shacl_file, format="turtle")
+            conforms, report, message = validate(d, shacl_graph=s, advanced=True, debug=False)
+        finally:
+            SPARQLFunction.execute_from_sparql_oxigraph = orig
+
+        assert not conforms
+        assert len(oxigraph_sparql_fn_calls) > 0, (
+            "Expected ex:concat to be invoked via execute_from_sparql_oxigraph "
+            "from the PersonFullNameLength SPARQL constraint"
+        )
+        concat_uri = "http://datashapes.org/shasf/tests/expression/advanced.test.shacl#concat"
+        assert any(str(node) == concat_uri for node in oxigraph_sparql_fn_calls)
 
 
 if __name__ == "__main__":

--- a/test/test_cmdline.py
+++ b/test/test_cmdline.py
@@ -46,6 +46,7 @@ else:
 
 if in_test_dir:
     lib_dir = os.path.abspath(os.path.join(test_dir, os.pardir))
+    PP = ENV_VARS["PYTHONPATH"]
     ENV_VARS["PYTHONPATH"] = pathsep.join((lib_dir, PP))
 
 scr_dir = f"scripts-{sys.version_info[0]}.{sys.version_info[1]}"
@@ -56,7 +57,6 @@ if path.exists(check_scrdir) and path.isdir(check_scrdir):
     has_scripts_dir = True
 else:
     has_scripts_dir = False
-
 
 if in_test_dir:
     bin_dir = path.join('..', bin_dir)
@@ -74,22 +74,22 @@ if path.exists(check_cli_script) and path.isfile(check_cli_script):
     has_cli_script = True
 else:
     has_cli_script = False
-
+project_dir = path.abspath(path.dirname(path.dirname(check_cli_script)))
 if has_scripts_dir:
     pyshacl_command = [f"{scr_dir}{sep}pyshacl"]
 elif has_bin_dir:
     pyshacl_command = [f"{bin_dir}{sep}pyshacl"]
 elif has_cli_script:
-    if is_windows:
-        if is_venv:
+    if is_venv:
+        if is_windows:
             pyshacl_command = [f"{virtual_bin}{sep}python.exe", cli_script]
         else:
-            pyshacl_command = [f"{bin_dir}{sep}python.exe", cli_script]
-    else:
-        if is_venv:
             pyshacl_command = [f"{virtual_bin}{sep}python3", cli_script]
-        else:
-            pyshacl_command = [f"{bin_dir}{sep}python3", cli_script]
+    else:
+        python_exe = sys.executable
+        pyshacl_command = [python_exe, cli_script]
+    PP = ENV_VARS["PYTHONPATH"]
+    ENV_VARS["PYTHONPATH"] = pathsep.join((project_dir, PP))
 else:
     pyshacl_command = ["pyshacl"]
 

--- a/test/test_cmdline_rules.py
+++ b/test/test_cmdline_rules.py
@@ -4,25 +4,40 @@ import os
 import platform
 import subprocess
 import sys
-from os import getenv, path
-from sys import stderr
+from os import getenv, path, pathsep, sep
 
 from rdflib import RDF, Graph, URIRef
 
+if platform.system() == "Windows":
+    is_windows = True
+    bin_dir = "Scripts"
+else:
+    is_windows = False
+    bin_dir = "bin"
+
 PATH = getenv("PATH", "")
 PP = getenv('PYTHONPATH', "")
-here_dir = path.abspath(path.dirname(__file__))
-ENV_VARS = {"PATH": PATH, "PYTHONPATH": ':'.join((here_dir, PP))}
+test_dir = path.abspath(path.dirname(__file__))
+ENV_VARS = {"PATH": PATH, "PYTHONPATH": ':'.join((test_dir, PP))}
 PH = getenv('PYTHONHOME', "")
 if PH:
     ENV_VARS['PYTHONHOME'] = PH
 VE = getenv('VIRTUAL_ENV', "")
 if VE:
     ENV_VARS['VIRTUAL_ENV'] = VE
-    virtual_bin = path.join(VE, "bin")
+    virtual_bin = path.join(VE, bin_dir)
     ENV_VARS['PATH'] = ':'.join((virtual_bin, PATH))
-abs_resources_dir = path.join(here_dir, 'resources')
+    is_venv = True
+else:
+    is_venv = False
+    virtual_bin = None
+
+abs_resources_dir = path.join(test_dir, 'resources')
 cmdline_files_dir = path.join(abs_resources_dir, 'cmdline_tests')
+if is_windows:
+    # The python debugger needs to know the SystemRoot and windir environment variables
+    ENV_VARS["SystemRoot"] = os.getenv("SystemRoot", "")
+    ENV_VARS["windir"] = os.getenv("windir", "")
 
 check_resources = path.join(path.abspath(os.getcwd()), 'resources')
 in_test_dir = False
@@ -32,10 +47,10 @@ else:
     in_test_dir = False
 
 if in_test_dir:
-    lib_dir = os.path.abspath(os.path.join(here_dir, os.pardir))
-    ENV_VARS["PYTHONPATH"] = ':'.join((lib_dir, PP))
+    lib_dir = os.path.abspath(os.path.join(test_dir, os.pardir))
+    PP = ENV_VARS["PYTHONPATH"]
+    ENV_VARS["PYTHONPATH"] = pathsep.join((lib_dir, PP))
 
-it = ENV_VARS["PYTHONPATH"].split(":")
 scr_dir = "scripts-{}.{}".format(sys.version_info[0], sys.version_info[1])
 if in_test_dir:
     scr_dir = path.join('..', scr_dir)
@@ -45,7 +60,6 @@ if path.exists(check_scrdir) and path.isdir(check_scrdir):
 else:
     has_scripts_dir = False
 
-bin_dir = "bin"
 if in_test_dir:
     bin_dir = path.join('..', bin_dir)
 check_bindir = path.join(path.abspath(os.getcwd()), bin_dir)
@@ -54,7 +68,7 @@ if path.exists(check_bindir) and path.isdir(check_bindir):
 else:
     has_bin_dir = False
 
-cli_rules_script = "pyshacl/cli_rules.py"
+cli_rules_script = f"pyshacl{sep}cli_rules.py"
 if in_test_dir:
     cli_rules_script = path.join('..', cli_rules_script)
 check_cli_script = path.join(path.abspath(os.getcwd()), cli_rules_script)
@@ -63,12 +77,22 @@ if path.exists(check_cli_script) and path.isfile(check_cli_script):
 else:
     has_cli_script = False
 
+project_dir = path.abspath(path.dirname(path.dirname(check_cli_script)))
 if has_scripts_dir:
-    pyshacl_rules_command = ["{}/pyshacl_rules".format(scr_dir)]
+    pyshacl_rules_command = [f"{scr_dir}{sep}pyshacl_rules"]
 elif has_bin_dir:
-    pyshacl_rules_command = ["{}/pyshacl_rules".format(bin_dir)]
+    pyshacl_rules_command = [f"{bin_dir}{sep}pyshacl_rules"]
 elif has_cli_script:
-    pyshacl_rules_command = ["python3", cli_rules_script]
+    if is_venv:
+        if is_windows:
+            pyshacl_rules_command = [f"{virtual_bin}{sep}python.exe", cli_rules_script]
+        else:
+            pyshacl_rules_command = [f"{virtual_bin}{sep}python3", cli_rules_script]
+    else:
+        python_exe = sys.executable
+        pyshacl_rules_command = [python_exe, cli_rules_script]
+    PP = ENV_VARS["PYTHONPATH"]
+    ENV_VARS["PYTHONPATH"] = pathsep.join((project_dir, PP))
 else:
     pyshacl_rules_command = ["pyshacl_rules"]
 

--- a/test/test_multiple_data_graphs.py
+++ b/test/test_multiple_data_graphs.py
@@ -45,8 +45,8 @@ def test_validate_each_multiple_graphs():
         shacl_graph=SHAPES_TTL,
     )
     assert len(results) == 2
-    assert results[DATA_GRAPH_OK][0] is True
-    assert results[DATA_GRAPH_BAD][0] is False
+    assert results[0][0] is True
+    assert results[1][0] is False
 
 def test_validate_each_multiple_graphs_via_mode():
     results = pyshacl.validate(
@@ -55,5 +55,5 @@ def test_validate_each_multiple_graphs_via_mode():
         multi_data_graphs_mode="validate_each",
     )
     assert len(results) == 2
-    assert results[DATA_GRAPH_OK][0] is True
-    assert results[DATA_GRAPH_BAD][0] is False
+    assert results[0][0] is True
+    assert results[1][0] is False

--- a/test/test_rules_oxigraph.py
+++ b/test/test_rules_oxigraph.py
@@ -1,0 +1,156 @@
+# -*- coding: utf-8 -*-
+"""\
+Tests for SHACL Rules (SPARQLRule, TripleRule) with an Oxigraph-backed DataGraph.
+
+These tests reuse the DASH rule test cases from test/resources/dash_tests/rules/
+and load the target data graph into a pyoxigraph Store so that pySHACL wraps it
+in the OxigraphDataGraph proxy and exercises the Oxigraph code paths for rules.
+"""
+
+import glob
+from os import path, walk
+
+import pytest
+from rdflib import RDF, URIRef
+
+import pyshacl
+from pyshacl.errors import ReportableRuntimeError
+from pyshacl.graph_abstraction import DataGraph, has_oxigraph
+
+pytestmark = pytest.mark.skipif(not has_oxigraph, reason="pyoxigraph is not installed")
+
+here_dir = path.abspath(path.dirname(__file__))
+dash_files_dir = path.join(here_dir, "resources", "dash_tests")
+
+# RDFS pre-inferencing via owlrl on an Oxigraph store is not used here; the DASH rule
+# test cases pass with inference='none' (see test_dash_validate.py parity).
+ALLOWABLE_NOT_IMPLEMENTED = []
+ALLOWABLE_FAILURES = ["/rules/triple/person2schema.test.ttl"]
+
+
+def load_oxigraph_store_from_file(file_path: str):
+    from pyoxigraph import RdfFormat, Store
+
+    store = Store()
+    with open(file_path, "rb") as f:
+        store.bulk_load(f.read(), format=RdfFormat.TURTLE)
+    return store
+
+
+cmdline_files_dir = path.join(here_dir, "resources", "cmdline_tests")
+rules_runner_data_file = path.join(cmdline_files_dir, "rules_d.ttl")
+rules_runner_shacl_file = path.join(cmdline_files_dir, "rules_s.ttl")
+
+
+dash_sparql_rules_files = []
+for x in walk(path.join(dash_files_dir, "rules", "sparql")):
+    for y in glob.glob(path.join(x[0], "*.test.ttl")):
+        dash_sparql_rules_files.append((y, None))
+
+
+@pytest.mark.parametrize("data_file, shacl_file", dash_sparql_rules_files)
+def test_sparql_rules_oxigraph(data_file, shacl_file):
+    """Run DASH SPARQLRule tests with the data graph backed by an Oxigraph store."""
+    data_store = load_oxigraph_store_from_file(data_file)
+    try:
+        val, _, v_text = pyshacl.validate(
+            data_store,
+            shacl_graph=shacl_file or data_file,
+            advanced=True,
+            inference="none",
+            check_dash_result=True,
+            debug=True,
+            meta_shacl=False,
+        )
+    except (NotImplementedError, ReportableRuntimeError) as e:
+        import traceback
+
+        print(e)
+        traceback.print_tb(e.__traceback__)
+        val = False
+        v_text = ""
+    assert val
+    print(v_text)
+
+
+dash_triple_rules_files = []
+for x in walk(path.join(dash_files_dir, "rules", "triple")):
+    for y in glob.glob(path.join(x[0], "*.test.ttl")):
+        if "person2schema.test.ttl" in y:
+            data_file = y.replace("person2schema.test.ttl", "person.ttl")
+            dash_triple_rules_files.append((data_file, y))
+        else:
+            dash_triple_rules_files.append((y, None))
+
+
+@pytest.mark.parametrize("data_file, shacl_file", dash_triple_rules_files)
+def test_triple_rules_oxigraph(data_file, shacl_file):
+    """Run DASH TripleRule tests with the data graph backed by an Oxigraph store."""
+    test_name = shacl_file or data_file
+    data_store = load_oxigraph_store_from_file(data_file)
+    try:
+        val, _, v_text = pyshacl.validate(
+            data_store,
+            shacl_graph=shacl_file or data_file,
+            advanced=True,
+            inference="none",
+            check_dash_result=True,
+            debug=True,
+            meta_shacl=False,
+        )
+    except NotImplementedError as ne:
+        for ani in ALLOWABLE_NOT_IMPLEMENTED:
+            if test_name.endswith(ani):
+                v_text = "Skipping not implemented feature in test: {}".format(test_name)
+                print(v_text)
+                val = True
+                break
+        else:
+            print(ne)
+            val = False
+            v_text = ""
+    except ReportableRuntimeError as e:
+        import traceback
+
+        print(e)
+        traceback.print_tb(e.__traceback__)
+        val = False
+        v_text = ""
+    try:
+        assert val
+    except AssertionError as ae:
+        for af in ALLOWABLE_FAILURES:
+            if test_name.endswith(af):
+                v_text = "Allowing failure in test: {}".format(test_name)
+                print(v_text)
+                break
+        else:
+            raise ae
+
+    print(v_text)
+
+
+def test_rules_runner_oxigraph():
+    """Run shacl_rules() with an Oxigraph-backed data graph (TripleRule + expressions)."""
+    data_store = load_oxigraph_store_from_file(rules_runner_data_file)
+    output_g = pyshacl.shacl_rules(
+        data_store, shacl_graph=rules_runner_shacl_file, advanced=True, debug=False
+    )
+    person_classes = set(
+        output_g.objects(
+            URIRef("http://datashapes.org/shasf/tests/expression/rules.test.data#Jenny"),
+            predicate=RDF.type,
+        )
+    )
+    assert URIRef("http://datashapes.org/shasf/tests/expression/rules.test.ont#Administrator") in person_classes
+    assert URIRef("http://datashapes.org/shasf/tests/expression/rules.test.ont#Person") in person_classes
+
+
+def test_oxigraph_data_graph_wrapper_used():
+    """Confirm that passing an ox.Store yields an OxigraphDataGraph wrapper."""
+    from pyoxigraph import Store
+
+    store = Store()
+    dg = DataGraph.from_oxigraph_store(store)
+    assert dg.is_oxigraph is True
+    assert type(dg).__name__ == "OxigraphDataGraph"

--- a/test/test_schema_org.py
+++ b/test/test_schema_org.py
@@ -38,7 +38,7 @@ def schema_org():
     # print(dataGraph.serialize(format='ttl').decode('utf8'))
 
     shaclDS = rdflib.Dataset()
-    shaclGraph = shaclDS.default_context
+    shaclGraph = shaclDS.default_graph
     shaclDS.graph(shaclGraph)
     shaclGraph.parse(data=shacl, format='ttl')
 


### PR DESCRIPTION
 Compatibility with Oxigraph stores.
- PySHACL can now validate a graph that is loaded into a PyOxigraph `pyoxigraph.Store` instance. 
- New `DataGraph` graph abstraction layer that wraps RDFLib `Graph`/`Dataset` and, when installed, `pyoxigraph.Store`.
- Validation and SHACL Rules expansion can use an Oxigraph-backed data graph for faster SPARQL execution.
- Install with the new optional extra: `pip install pyshacl[oxigraph]`.
- Pass a `pyoxigraph.Store` directly to `validate()` or `shacl_rules()`.
 SHACL Functions and SHACL-JS Functions now register and execute on both RDFLib and Oxigraph SPARQL engines.
 - SPARQL constraints can invoke SHACL Functions as SPARQL extension functions when using an Oxigraph-backed data graph.
- Python 3.13 support in the test matrix.
  - `pyduktape2` dependency is now version-split for Python 3.13+.


- Dropped `rdflib.ConjunctiveGraph` support throughout the codebase.
  - ConjunctiveGraph has been deprecatd in RDFLib for a long time, it will be gone in RDFLib 8. Removing it now from PySHACL to prevent compatibility issues later.
  - Multigraph inputs must be an `rdflib.Dataset`; bare `rdflib.Graph` remain supported for single-graph use.
- Adapted to RDFLib 7.3+ API changes: `default_context` has been replaced with `default_graph`, and `contexts()` replaced with `graphs()`.
  - Resolves #316
- Updated minimum dependency versions:
  - `rdflib[html]>=7.3.0,<8.0`
  - `owlrl>=7.6.1,<8`
- `validate_each()` now returns a dict keyed by input index (`int`) instead of by source identifier.
- Internal validation and rules expansion now operate on the `DataGraph` wrapper rather than raw RDFLib graph objects.
- SPARQL prefix resolution for shapes graphs stored in a `Dataset` now reads `sh:declare` blocks from the default graph.
- DASH conformance checking now enumerates named graphs with `Dataset.graphs()` instead of the deprecated `contexts()` API.

- OWL `owl:imports` over HTTP no longer leaves closed `HTTPResponse` objects that trigger finalizer errors during garbage collection.
  - Fixes #319

### Removed
- Support for `rdflib.ConjunctiveGraph` as a data graph, shapes graph, or ontology graph input type.
