### PR TITLE
Add future annotations to keep Python 3.9 support

### DIFF
--- a/pyshacl/graph_abstraction.py
+++ b/pyshacl/graph_abstraction.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 try:
     from pyoxigraph import (
         BlankNode as ox_BlankNode,


### PR DESCRIPTION
pySHACL 0.40.0 can't run on Python 3.9 because `graph_abstraction.py` uses Python 3.10 `X | Y` syntax for type union (see line 162 below), without `from __future__ import annotations`.

https://github.com/RDFLib/pySHACL/blob/9eeb9bf670da814c3c55125d55c9cfeea738bb04/pyshacl/graph_abstraction.py#L160-L162

Using pySHACL 0.40.0 on Python 3.9 will get this error:

> TypeError: unsupported operand type(s) for |: 'type' and 'ABCMeta'

## What this PR does?

Add `from __future__ import annotations` to keep Python 3.9 support. Similar pattern to existing code:

https://github.com/RDFLib/pySHACL/blob/9eeb9bf670da814c3c55125d55c9cfeea738bb04/pyshacl/functions/shacl_function.py#L3

https://github.com/RDFLib/pySHACL/blob/9eeb9bf670da814c3c55125d55c9cfeea738bb04/pyshacl/functions/shacl_function.py#L60
